### PR TITLE
feat: text editor: customize font family and font size

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -249,11 +249,11 @@ msgstr "Main Style"
 msgid "主页"
 msgstr "WebGAL Home"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:79
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:95
 msgid "代码编辑器"
 msgstr "Code Editor"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:97
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:135
 msgid "你已启用实验性快速预览，该功能将大幅提升实时预览效率，但可能出现异常。特别提示：不要在上一次实时预览跳转还没有完全结束时（尤其是有动画没有结束时）再次跳转。"
 msgstr "You have enabled the experimental fast preview, which will greatly improve the efficiency of real-time preview, but there may be exceptions. Special tips: Do not jump again when the last real-time preview jump is not completely finished (especially when the animation is not finished)."
 
@@ -358,7 +358,7 @@ msgstr "About"
 msgid "关联立绘"
 msgstr "Associated figure"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:94
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132
 msgid "关闭"
 msgstr "Disabled"
 
@@ -407,7 +407,7 @@ msgid "最小高度"
 msgstr "Min Height"
 
 #: src/pages/dashboard/About.tsx:41
-#: src/pages/dashboard/DashBoard.tsx:198
+#: src/pages/dashboard/DashBoard.tsx:180
 msgid "最新版本"
 msgstr "Latest Version"
 
@@ -527,7 +527,7 @@ msgstr "Single line comment"
 msgid "反射电影滤镜"
 msgstr "Reflection film filter"
 
-#: src/pages/dashboard/DashBoard.tsx:193
+#: src/pages/dashboard/DashBoard.tsx:175
 msgid "发现新版本"
 msgstr "New version detected"
 
@@ -560,10 +560,10 @@ msgstr "Start, switch or stop the playback of background music"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
 msgid "启动图"
-msgstr "Startup image"
+msgstr "Startup image<<<<<<< Updated upstream"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:94
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132
 msgid "启用"
 msgstr "Enabled"
 
@@ -631,10 +631,12 @@ msgstr "Margin"
 msgid "大"
 msgstr "Large"
 
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:99
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:58
 msgid "字体"
 msgstr "Font"
 
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:105
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:41
 msgid "字体大小"
 msgstr "Font size"
@@ -651,25 +653,25 @@ msgstr "Font Weight"
 msgid "定位方式"
 msgstr "Positioning"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:59
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:75
 msgid "实时预览"
 msgstr "Live preview"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:163
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:74
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:90
 msgid "实时预览关闭"
 msgstr "Live preview off"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:62
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:78
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "Live preview fast-forwards the game to the edited statement, but with limitations. The effects of statements from previous scenes, such as variables, won't be reflected in the preview."
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:163
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:74
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:90
 msgid "实时预览打开"
 msgstr "Live preview on"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:88
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:126
 msgid "实验性快速预览"
 msgstr "Experimental fast preview"
 
@@ -753,7 +755,7 @@ msgstr "Left side figure"
 msgid "左对齐"
 msgstr "Left align"
 
-#: src/pages/dashboard/DashBoard.tsx:149
+#: src/pages/dashboard/DashBoard.tsx:131
 msgid "已创建"
 msgstr "Created"
 
@@ -799,11 +801,11 @@ msgid "张开嘴"
 msgstr "Open mouth"
 
 #: src/pages/dashboard/About.tsx:37
-#: src/pages/dashboard/DashBoard.tsx:197
+#: src/pages/dashboard/DashBoard.tsx:179
 msgid "当前版本"
 msgstr "Current version"
 
-#: src/pages/dashboard/DashBoard.tsx:207
+#: src/pages/dashboard/DashBoard.tsx:189
 msgid "忽略此版本"
 msgstr "Ignore this version"
 
@@ -1179,7 +1181,7 @@ msgstr "Title background music"
 msgid "根文本长度 (rem)"
 msgstr "Root Font Size (rem)"
 
-#: src/pages/dashboard/DashBoard.tsx:255
+#: src/pages/dashboard/DashBoard.tsx:237
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:110
 msgid "模板"
 msgstr "Template"
@@ -1204,7 +1206,7 @@ msgstr "Play BGM normally"
 msgid "此指令将结束游戏"
 msgstr "This command will end the game"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:85
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:122
 msgid "永不换行"
 msgstr "Never wrap"
 
@@ -1274,7 +1276,7 @@ msgstr "Clear special effects of current stage"
 msgid "清除特效"
 msgstr "Clear effects"
 
-#: src/pages/dashboard/DashBoard.tsx:253
+#: src/pages/dashboard/DashBoard.tsx:235
 msgid "游戏"
 msgstr "Games"
 
@@ -1498,7 +1500,7 @@ msgstr "Script editor"
 msgid "自动"
 msgstr "Auto"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:85
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:122
 msgid "自动换行"
 msgstr "Auto wrap"
 
@@ -1529,7 +1531,7 @@ msgid "舞台对象控制"
 msgstr "Stage object control"
 
 #: src/pages/dashboard/About.tsx:48
-#: src/pages/dashboard/DashBoard.tsx:203
+#: src/pages/dashboard/DashBoard.tsx:185
 msgid "获取最新版本"
 msgstr "Download Latest Version"
 
@@ -1635,10 +1637,10 @@ msgstr "This command is not recognized, please open script editing mode to edit 
 msgid "该文件类型不支持预览"
 msgstr "This file type does not support preview"
 
-#: src/pages/dashboard/DashBoard.tsx:236
-#: src/pages/dashboard/DashBoard.tsx:237
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:40
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:46
+#: src/pages/dashboard/DashBoard.tsx:218
+#: src/pages/dashboard/DashBoard.tsx:219
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:56
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:62
 msgid "语言"
 msgstr "Language"
 

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -560,7 +560,7 @@ msgstr "Start, switch or stop the playback of background music"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
 msgid "启动图"
-msgstr "Startup image<<<<<<< Updated upstream"
+msgstr "Startup image"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -249,11 +249,11 @@ msgstr "メインスタイル"
 msgid "主页"
 msgstr "WebGALホーム"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:79
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:95
 msgid "代码编辑器"
 msgstr "コードエディタ"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:97
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:135
 msgid "你已启用实验性快速预览，该功能将大幅提升实时预览效率，但可能出现异常。特别提示：不要在上一次实时预览跳转还没有完全结束时（尤其是有动画没有结束时）再次跳转。"
 msgstr "実験的な高速プレビューを有効にすると、リアルタイムプレビューの効率が大幅に向上しますが、異常が発生する可能性があります。特別なヒント：前回のリアルタイムプレビューのジャンプが完全に終了していない（特にアニメーションが終了していない）ときに、再度ジャンプしないでください。"
 
@@ -358,7 +358,7 @@ msgstr "About"
 msgid "关联立绘"
 msgstr "関連する立ち絵"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:94
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132
 msgid "关闭"
 msgstr "閉鎖中"
 
@@ -407,7 +407,7 @@ msgid "最小高度"
 msgstr "最小高さ"
 
 #: src/pages/dashboard/About.tsx:41
-#: src/pages/dashboard/DashBoard.tsx:198
+#: src/pages/dashboard/DashBoard.tsx:180
 msgid "最新版本"
 msgstr "最新バージョン"
 
@@ -527,7 +527,7 @@ msgstr "一行コメント"
 msgid "反射电影滤镜"
 msgstr "反射映画"
 
-#: src/pages/dashboard/DashBoard.tsx:193
+#: src/pages/dashboard/DashBoard.tsx:175
 msgid "发现新版本"
 msgstr "新しいバージョンが検出されました"
 
@@ -560,10 +560,10 @@ msgstr "BGMの再生を開始、切り替え、または停止する"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
 msgid "启动图"
-msgstr "ロゴ"
+msgstr "ロゴ<<<<<<< Updated upstream"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:94
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132
 msgid "启用"
 msgstr "有効化"
 
@@ -631,10 +631,12 @@ msgstr "マージン"
 msgid "大"
 msgstr "大きい"
 
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:99
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:58
 msgid "字体"
 msgstr "フォント"
 
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:105
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:41
 msgid "字体大小"
 msgstr "フォントサイズ"
@@ -651,25 +653,25 @@ msgstr "フォントの太さ"
 msgid "定位方式"
 msgstr "位置決め方法"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:59
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:75
 msgid "实时预览"
 msgstr "リアルタイムプレビュー"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:163
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:74
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:90
 msgid "实时预览关闭"
 msgstr "リアルタイムプレビューオフ"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:62
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:78
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "リアルタイムプレビューはゲームを制限付きで早送りし、以前のシーンの効果はマッピングされません。"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:163
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:74
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:90
 msgid "实时预览打开"
 msgstr "リアルタイムプレビューオン"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:88
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:126
 msgid "实验性快速预览"
 msgstr "実験的な高速プレビュー"
 
@@ -753,7 +755,7 @@ msgstr "左の立ち絵"
 msgid "左对齐"
 msgstr "左揃え"
 
-#: src/pages/dashboard/DashBoard.tsx:149
+#: src/pages/dashboard/DashBoard.tsx:131
 msgid "已创建"
 msgstr "作成済み"
 
@@ -799,11 +801,11 @@ msgid "张开嘴"
 msgstr "開いた口"
 
 #: src/pages/dashboard/About.tsx:37
-#: src/pages/dashboard/DashBoard.tsx:197
+#: src/pages/dashboard/DashBoard.tsx:179
 msgid "当前版本"
 msgstr "現在のバージョン"
 
-#: src/pages/dashboard/DashBoard.tsx:207
+#: src/pages/dashboard/DashBoard.tsx:189
 msgid "忽略此版本"
 msgstr "このバージョンを無視する"
 
@@ -1179,7 +1181,7 @@ msgstr "タイトルのBGM"
 msgid "根文本长度 (rem)"
 msgstr "ルートテキストの長さ (rem)"
 
-#: src/pages/dashboard/DashBoard.tsx:255
+#: src/pages/dashboard/DashBoard.tsx:237
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:110
 msgid "模板"
 msgstr "テンプレート"
@@ -1204,7 +1206,7 @@ msgstr "BGMを再生"
 msgid "此指令将结束游戏"
 msgstr "このコマンドはすべてのゲームが終わるときに使用"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:85
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:122
 msgid "永不换行"
 msgstr "折り返しなし"
 
@@ -1274,7 +1276,7 @@ msgstr "現在のステージの特殊効果をクリア"
 msgid "清除特效"
 msgstr "特殊効果をクリア"
 
-#: src/pages/dashboard/DashBoard.tsx:253
+#: src/pages/dashboard/DashBoard.tsx:235
 msgid "游戏"
 msgstr "ゲーム"
 
@@ -1498,7 +1500,7 @@ msgstr "スクリプトエディタ"
 msgid "自动"
 msgstr "自動"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:85
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:122
 msgid "自动换行"
 msgstr "自動折り返し"
 
@@ -1529,7 +1531,7 @@ msgid "舞台对象控制"
 msgstr "ステージオブジェクトコントロール"
 
 #: src/pages/dashboard/About.tsx:48
-#: src/pages/dashboard/DashBoard.tsx:203
+#: src/pages/dashboard/DashBoard.tsx:185
 msgid "获取最新版本"
 msgstr "最新バージョンをダウンロード"
 
@@ -1635,10 +1637,10 @@ msgstr "このコマンドは認識されません、スクリプト編集モー
 msgid "该文件类型不支持预览"
 msgstr "このファイルタイプはプレビューをサポートしていません"
 
-#: src/pages/dashboard/DashBoard.tsx:236
-#: src/pages/dashboard/DashBoard.tsx:237
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:40
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:46
+#: src/pages/dashboard/DashBoard.tsx:218
+#: src/pages/dashboard/DashBoard.tsx:219
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:56
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:62
 msgid "语言"
 msgstr "言語"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -560,7 +560,7 @@ msgstr "BGMの再生を開始、切り替え、または停止する"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
 msgid "启动图"
-msgstr "ロゴ<<<<<<< Updated upstream"
+msgstr "ロゴ"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -580,7 +580,7 @@ msgstr "启动、切换或停止背景音乐的播放"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
 msgid "启动图"
-msgstr "启动图<<<<<<< Updated upstream"
+msgstr "启动图"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -265,11 +265,11 @@ msgstr "主要样式"
 msgid "主页"
 msgstr "主页"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:79
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:95
 msgid "代码编辑器"
 msgstr "代码编辑器"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:97
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:135
 msgid "你已启用实验性快速预览，该功能将大幅提升实时预览效率，但可能出现异常。特别提示：不要在上一次实时预览跳转还没有完全结束时（尤其是有动画没有结束时）再次跳转。"
 msgstr "你已启用实验性快速预览，该功能将大幅提升实时预览效率，但可能出现异常。特别提示：不要在上一次实时预览跳转还没有完全结束时（尤其是有动画没有结束时）再次跳转。"
 
@@ -378,7 +378,7 @@ msgstr "关于"
 msgid "关联立绘"
 msgstr "关联立绘"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:94
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132
 msgid "关闭"
 msgstr "关闭"
 
@@ -427,7 +427,7 @@ msgid "最小高度"
 msgstr "最小高度"
 
 #: src/pages/dashboard/About.tsx:41
-#: src/pages/dashboard/DashBoard.tsx:198
+#: src/pages/dashboard/DashBoard.tsx:180
 msgid "最新版本"
 msgstr "最新版本"
 
@@ -547,7 +547,7 @@ msgstr "单行注释"
 msgid "反射电影滤镜"
 msgstr "反射电影滤镜"
 
-#: src/pages/dashboard/DashBoard.tsx:193
+#: src/pages/dashboard/DashBoard.tsx:175
 msgid "发现新版本"
 msgstr "发现新版本"
 
@@ -580,10 +580,10 @@ msgstr "启动、切换或停止背景音乐的播放"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
 msgid "启动图"
-msgstr "启动图"
+msgstr "启动图<<<<<<< Updated upstream"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:94
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:132
 msgid "启用"
 msgstr "启用"
 
@@ -651,10 +651,12 @@ msgstr "外边距"
 msgid "大"
 msgstr "大"
 
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:99
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:58
 msgid "字体"
 msgstr "字体"
 
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:105
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:41
 msgid "字体大小"
 msgstr "字体大小"
@@ -671,25 +673,25 @@ msgstr "字重"
 msgid "定位方式"
 msgstr "定位方式"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:59
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:75
 msgid "实时预览"
 msgstr "实时预览"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:163
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:74
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:90
 msgid "实时预览关闭"
 msgstr "实时预览关闭"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:62
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:78
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:163
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:74
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:90
 msgid "实时预览打开"
 msgstr "实时预览打开"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:88
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:126
 msgid "实验性快速预览"
 msgstr "实验性快速预览"
 
@@ -773,7 +775,7 @@ msgstr "左侧立绘"
 msgid "左对齐"
 msgstr "左对齐"
 
-#: src/pages/dashboard/DashBoard.tsx:149
+#: src/pages/dashboard/DashBoard.tsx:131
 msgid "已创建"
 msgstr "已创建"
 
@@ -819,11 +821,11 @@ msgid "张开嘴"
 msgstr "张开嘴"
 
 #: src/pages/dashboard/About.tsx:37
-#: src/pages/dashboard/DashBoard.tsx:197
+#: src/pages/dashboard/DashBoard.tsx:179
 msgid "当前版本"
 msgstr "当前版本"
 
-#: src/pages/dashboard/DashBoard.tsx:207
+#: src/pages/dashboard/DashBoard.tsx:189
 msgid "忽略此版本"
 msgstr "忽略此版本"
 
@@ -1199,7 +1201,7 @@ msgstr "标题背景音乐"
 msgid "根文本长度 (rem)"
 msgstr "根文本长度 (rem)"
 
-#: src/pages/dashboard/DashBoard.tsx:255
+#: src/pages/dashboard/DashBoard.tsx:237
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:110
 msgid "模板"
 msgstr "模板"
@@ -1224,7 +1226,7 @@ msgstr "正常播放 BGM"
 msgid "此指令将结束游戏"
 msgstr "此指令将结束游戏"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:85
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:122
 msgid "永不换行"
 msgstr "永不换行"
 
@@ -1294,7 +1296,7 @@ msgstr "清除当前舞台的特殊效果"
 msgid "清除特效"
 msgstr "清除特效"
 
-#: src/pages/dashboard/DashBoard.tsx:253
+#: src/pages/dashboard/DashBoard.tsx:235
 msgid "游戏"
 msgstr "游戏"
 
@@ -1518,7 +1520,7 @@ msgstr "脚本编辑器"
 msgid "自动"
 msgstr "自动"
 
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:85
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:122
 msgid "自动换行"
 msgstr "自动换行"
 
@@ -1549,7 +1551,7 @@ msgid "舞台对象控制"
 msgstr "舞台对象控制"
 
 #: src/pages/dashboard/About.tsx:48
-#: src/pages/dashboard/DashBoard.tsx:203
+#: src/pages/dashboard/DashBoard.tsx:185
 msgid "获取最新版本"
 msgstr "获取最新版本"
 
@@ -1655,10 +1657,10 @@ msgstr "该指令没有被识别，请打开脚本编辑模式以手动编辑"
 msgid "该文件类型不支持预览"
 msgstr "该文件类型不支持预览"
 
-#: src/pages/dashboard/DashBoard.tsx:236
-#: src/pages/dashboard/DashBoard.tsx:237
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:40
-#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:46
+#: src/pages/dashboard/DashBoard.tsx:218
+#: src/pages/dashboard/DashBoard.tsx:219
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:56
+#: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:62
 msgid "语言"
 msgstr "语言"
 

--- a/packages/origine2/src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx
+++ b/packages/origine2/src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx
@@ -1,7 +1,7 @@
 import s from './settingsTab.module.scss';
 import TopbarTab from "@/pages/editor/Topbar/components/TopbarTab";
-import {TabItem} from "@/pages/editor/Topbar/components/TabItem";
-import {IconWithTextItem} from "@/pages/editor/Topbar/components/IconWithTextItem";
+import { TabItem } from "@/pages/editor/Topbar/components/TabItem";
+import { IconWithTextItem } from "@/pages/editor/Topbar/components/IconWithTextItem";
 import {
   ArrowEnterLeft24Filled,
   ArrowEnterLeft24Regular, ArrowRepeatAll24Filled, ArrowRepeatAllOff24Regular,
@@ -15,9 +15,11 @@ import {
   Navigation24Filled,
   Navigation24Regular,
 } from '@fluentui/react-icons';
-import {Menu, MenuTrigger, MenuPopover, MenuList, MenuItem, Tooltip} from '@fluentui/react-components';
+import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItem, Tooltip, Input, Combobox, Option } from '@fluentui/react-components';
 import useEditorStore from '@/store/useEditorStore';
-import {t} from '@lingui/macro';
+import { t } from '@lingui/macro';
+import { candidateFontSizes } from './constants';
+import { useEffect, useState } from 'react';
 
 export function SettingsTab() {
 
@@ -36,13 +38,27 @@ export function SettingsTab() {
   const isUseExpSyncFast = useEditorStore.use.isUseExpFastSync();
   const updateIsUseExpSyncFast = useEditorStore.use.updateIsUseExpFastSync();
 
+  const editorFontFamily = useEditorStore.use.editorFontFamily();
+  const editorFontSize = useEditorStore.use.editorFontSize();
+  const updateEditorFontFamily = useEditorStore.use.updateEditorFontFamily();
+  const updateEditorFontSize = useEditorStore.use.updateEditorFontSize();
+
+  const [tempFontSize, setTempFontSize] = useState(editorFontSize.toString());
+
+  useEffect(() => {
+    const testValue = Number.parseFloat(tempFontSize);
+    if (!isNaN(testValue)) {
+      updateEditorFontSize(testValue);
+    }
+  }, [tempFontSize]);
+
   return <TopbarTab>
     <TabItem title={t`语言`}>
       <Menu>
         <MenuTrigger>
           <div>
             <IconWithTextItem
-              icon={<LocalLanguageIcon className={s.iconColor}/>}
+              icon={<LocalLanguageIcon className={s.iconColor} />}
               text={t`语言`}
             />
           </div>
@@ -70,27 +86,49 @@ export function SettingsTab() {
             onClick={() => {
               updateIsEnableLivePreview(!isEnableLivePreview);
             }}
-            icon={isEnableLivePreview ? <LiveIcon className={s.iconColor}/> : <LiveOffIcon className={s.iconColor}/>}
+            icon={isEnableLivePreview ? <LiveIcon className={s.iconColor} /> : <LiveOffIcon className={s.iconColor} />}
             text={isEnableLivePreview ? t`实时预览打开` : t`实时预览关闭`}
           />
         </div>
       </Tooltip>
     </TabItem>
     <TabItem title={t`代码编辑器`}>
-      <IconWithTextItem
-        onClick={() => {
-          updateIsAutoWarp(!isAutoWarp);
-        }}
-        icon={isAutoWarp ? <ArrowEnterLeftIcon className={s.iconColor}/> : <NavigationIcon className={s.iconColor}/>}
-        text={isAutoWarp ? t`自动换行` : t`永不换行`}
-      />
+
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <div style={{ marginLeft: 10 }}>
+          <div className={s.prompt}>{t`字体`}</div>
+          <Input className={s.fontFamilyInput}
+            value={editorFontFamily}
+            onChange={(ev) => updateEditorFontFamily(ev.target.value)} />
+        </div>
+        <div style={{ marginRight: 10 }}>
+          <div className={s.prompt}>{t`字体大小`}</div>
+          <Combobox freeform
+            style={{ minWidth: 'unset' }}
+            input={{ style: { width: '40px' } }}
+            value={tempFontSize}
+            onChange={(ev) => setTempFontSize(ev.target.value)}
+            onOptionSelect={(_, data) => setTempFontSize(data.optionValue ?? '')}>
+            {candidateFontSizes.map((option) => (
+              <Option key={option}>{option.toString()}</Option>
+            ))}
+          </Combobox>
+        </div>
+        <IconWithTextItem
+          onClick={() => {
+            updateIsAutoWarp(!isAutoWarp);
+          }}
+          icon={isAutoWarp ? <ArrowEnterLeftIcon className={s.iconColor} /> : <NavigationIcon className={s.iconColor} />}
+          text={isAutoWarp ? t`自动换行` : t`永不换行`}
+        />
+      </div>
     </TabItem>
     <TabItem title={t`实验性快速预览`}>
       <IconWithTextItem
         onClick={() => {
           updateIsUseExpSyncFast(!isUseExpSyncFast);
         }}
-        icon={isUseExpSyncFast ? <ArrowRepeatAll24Filled className={s.iconColor}/> : <ArrowRepeatAllOff24Regular className={s.iconColor}/>}
+        icon={isUseExpSyncFast ? <ArrowRepeatAll24Filled className={s.iconColor} /> : <ArrowRepeatAllOff24Regular className={s.iconColor} />}
         text={isUseExpSyncFast ? t`启用` : t`关闭`}
       />
       {isUseExpSyncFast && <div className={s.tips}>

--- a/packages/origine2/src/pages/editor/Topbar/tabs/Settings/constants.ts
+++ b/packages/origine2/src/pages/editor/Topbar/tabs/Settings/constants.ts
@@ -1,0 +1,3 @@
+export const candidateFontSizes: number[] = [
+  8, 9, 10, 10.5, 11, 12, 14, 16, 18, 20, 24, 28
+];

--- a/packages/origine2/src/pages/editor/Topbar/tabs/Settings/settingsTab.module.scss
+++ b/packages/origine2/src/pages/editor/Topbar/tabs/Settings/settingsTab.module.scss
@@ -1,15 +1,16 @@
-.iconColor{
+.iconColor {
   color: var(--primary);
   font-size: 25px;
   height: 25px;
   width: 25px;
 }
-.previewTips{
+
+.previewTips {
   color: var(--primary);
   text-align: left;
 }
 
-.tips{
+.tips {
   color: var(--primary);
   font-weight: bolder;
   font-size: smaller;
@@ -19,4 +20,13 @@
   background: var(--primary-5pct);
   padding: 4px;
   border-radius: 4px;
+}
+
+.fontFamilyInput {
+  max-width: 320px;
+  margin: 0 5px 0 0;
+}
+
+.prompt {
+  padding-bottom: 8px;
 }

--- a/packages/origine2/src/store/useEditorStore.ts
+++ b/packages/origine2/src/store/useEditorStore.ts
@@ -1,5 +1,6 @@
 import { IEditorState, IEditorAction } from '@/types/editor';
 import createSelectors from '@/utils/createSelectors';
+import { updateUserConfiguration } from '@codingame/monaco-vscode-configuration-service-override';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
@@ -11,11 +12,13 @@ export const registerSubPageChangedCallback = (callback: (subPage: string) => vo
 
 const useEditorStoreBase = create<IEditorState & IEditorAction>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       page: 'dashboard',
       subPage: '',
       expand: 0,
       language: 'zhCn',
+      editorFontFamily: "Consolas, 'Courier New', monospace",
+      editorFontSize: 14,
       isAutoHideToolbar: false,
       isEnableLivePreview: false,
       isAutoWarp: false,
@@ -28,6 +31,24 @@ const useEditorStoreBase = create<IEditorState & IEditorAction>()(
       },
       updateExpand: (index) => set({expand: index}),
       updateLanguage: (language) => set({language}),
+      updateEditorFontFamily: (editorFontFamily) => {
+        set({editorFontFamily});
+        updateUserConfiguration(`{
+          "workbench.colorTheme": "WebGAL White",
+          "editor.semanticHighlighting.enabled": "configuredByTheme",
+          "editor.fontFamily": "${get().editorFontFamily}",
+          "editor.fontSize": ${get().editorFontSize},
+        }`);
+      },
+      updateEditorFontSize: (editorFontSize) => {
+        set({editorFontSize});
+        updateUserConfiguration(`{
+          "workbench.colorTheme": "WebGAL White",
+          "editor.semanticHighlighting.enabled": "configuredByTheme",
+          "editor.fontFamily": "${get().editorFontFamily}",
+          "editor.fontSize": ${get().editorFontSize},
+        }`);
+      },
       updateIisAutoHideToolbar: (isAutoHideToolbar) => set({isAutoHideToolbar}),
       updateIsEnableLivePreview: (isEnableLivePreview) => set({isEnableLivePreview}),
       updateIsAutoWarp: (isAutoWarp) => set({isAutoWarp}),

--- a/packages/origine2/src/types/editor.ts
+++ b/packages/origine2/src/types/editor.ts
@@ -6,6 +6,8 @@ export interface IEditorState {
   subPage: string,
   expand: number,
   language: 'zhCn' | 'en' | 'ja',
+  editorFontFamily: string,
+  editorFontSize: number,
   isAutoHideToolbar: boolean, // 是否自动隐藏工具栏
   isEnableLivePreview: boolean, // 是否开启实时预览
   isAutoWarp: boolean, // 是否开启自动换行
@@ -18,6 +20,8 @@ export interface IEditorAction {
   updateSubPage: (subPage: IEditorState['subPage']) => void,
   updateExpand: (index: IEditorState['expand']) => void,
   updateLanguage: (language: IEditorState['language']) => void,
+  updateEditorFontFamily: (editorFontFamily: IEditorState['editorFontFamily']) => void,
+  updateEditorFontSize: (editorFontSize: IEditorState['editorFontSize']) => void,
   updateIisAutoHideToolbar: (isAutoHideToolbar: IEditorState['isAutoHideToolbar']) => void,
   updateIsEnableLivePreview: (isEnableLivePreview: IEditorState['isEnableLivePreview']) => void,
   updateIsAutoWarp: (isAutoWarp: IEditorState['isAutoWarp']) => void,

--- a/packages/origine2/src/webgalscript/lsp.ts
+++ b/packages/origine2/src/webgalscript/lsp.ts
@@ -47,9 +47,11 @@ export const runClient = async () => {
   });
 
   updateUserConfiguration(`{
-  "workbench.colorTheme": "WebGAL White",
-  "editor.semanticHighlighting.enabled": "configuredByTheme",
-}`);
+    "workbench.colorTheme": "WebGAL White",
+    "editor.semanticHighlighting.enabled": "configuredByTheme",
+    "editor.fontFamily": "${useEditorStore.getState().editorFontFamily}",
+    "editor.fontSize": ${useEditorStore.getState().editorFontSize},
+  }`);
 
   monaco.languages.register({
     id: 'webgal',


### PR DESCRIPTION
Resolve #325.

Allows the user to customize font family and font size in the `top bar -> Settings -> Code Editor` pane.

For now, this can be an ad hoc implementation. In the future, we can create a JSON configuration file for the text editor (with the same settings as those in VS Code).