### PR TITLE
feat(ci): Retrieve the Node.js version from package.json

### DIFF
--- a/.github/workflows/build-terre.yml
+++ b/.github/workflows/build-terre.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         env:
@@ -35,7 +35,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build Stage 1
         run: |
@@ -124,7 +124,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         env:
@@ -144,7 +144,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         shell: bash
@@ -163,7 +163,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         shell: bash

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         env:
@@ -37,7 +37,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build Stage 1
         run: |
@@ -126,7 +126,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         env:
@@ -146,7 +146,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         shell: bash
@@ -165,7 +165,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         env:
@@ -40,7 +40,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build Stage 1
         run: |
@@ -132,7 +132,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         env:
@@ -154,7 +154,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         shell: bash
@@ -175,7 +175,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: package.json
           cache: 'yarn'
       - name: Build
         shell: bash

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
       "**/electron/**"
     ]
   },
-  "dependencies": {},
   "devDependencies": {
     "concurrently": "^7.2.2",
     "iconv-lite": "^0.6.3"
+  },
+  "engines": {
+    "node": "18"
   }
 }


### PR DESCRIPTION
## Overview

Updated GitHub Actions workflows to use node version from package.json.

## Key Changes

- Modified GitHub Actions workflows to dynamically use Node.js version from package.json
- Added explicit Node.js engine specification in package.json

## Specific Updates

In `.github/workflows/build-terre.yml`:
- Changed `node-version: 18` to `node-version-file: package.json`

In `.github/workflows/pr-check.yml`:
- Similar workflow configuration updates as in build-terre workflow

In `.github/workflows/release.yml`:
- Similar workflow configuration updates as in build-terre workflow

In `package.json`:
- Added `engines` field to specify Node.js version