### PR TITLE
chore: specify yarn package manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
   },
   "engines": {
     "node": "18"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## 概述

更新了 `package.json` 文件，明确指定了 Yarn 包管理器的版本，以确保项目中的依赖管理保持一致。

## 为什么

Yarn 官方不推荐全局安装，在它们的[官方文档](https://yarnpkg.com/corepack)中可以看到以下理由：

> You may notice by reading our [installation guide](https://yarnpkg.com/getting-started/install) that we don't tell you to run npm install -g yarn to install Yarn - we even recommend against it. The reason is simple: just like your project dependencies must be locked, so should be the package manager itself.

> Installing Yarn as a global binary meant you always used whatever was the latest version published. Most of the time it worked fine, but every once in a while something was shipped that could impact the way your project was installed - be it a bugfix, new bug, or breaking change.

通过指定 `packageManager`，可以使用 [Corepack](https://nodejs.org/api/corepack.html) 按项目安装所需的包管理器版本。

此举还可以避免本地开发时多个 Yarn 版本冲突问题。