### PR TITLE
feat: Support adjustment filter

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -122,7 +122,7 @@ msgstr "playEffect: Choose a sound effect file;"
 msgid "playVideo:选择视频文件;"
 msgstr "playVideo: Choose a video file;"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:121
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
 msgid "RGB电影滤镜"
 msgstr "RGB film"
 
@@ -160,19 +160,19 @@ msgstr "WebGAL Classic"
 msgid "WebGAL Standard"
 msgstr "WebGAL Standard"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:86
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:100
 msgid "X轴位移："
 msgstr " X："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:95
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
 msgid "X轴缩放："
 msgstr " Scale x："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:90
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
 msgid "Y轴位移："
 msgstr " Y："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
 msgid "Y轴缩放："
 msgstr " Scale y："
 
@@ -272,9 +272,17 @@ msgstr "Main Style"
 msgid "主页"
 msgstr "WebGAL Home"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+msgid "亮度："
+msgstr "Brightness:"
+
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:97
 msgid "代码编辑器"
 msgstr "Code Editor"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+msgid "伽马值："
+msgstr "Gamma:"
 
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:137
 msgid "你已启用实验性快速预览，该功能将大幅提升实时预览效率，但可能出现异常。特别提示：不要在上一次实时预览跳转还没有完全结束时（尤其是有动画没有结束时）再次跳转。"
@@ -378,7 +386,7 @@ msgstr "Stop the BGM"
 msgid "像素"
 msgstr "pixel"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
 msgid "光辉电影滤镜"
 msgstr "Godray film"
 
@@ -569,7 +577,7 @@ msgstr "Unit milliseconds. 0~ valid"
 msgid "单行注释"
 msgstr "Single line comment"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:119
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
 msgid "反射电影滤镜"
 msgstr "Reflection film filter"
 
@@ -584,7 +592,7 @@ msgstr "New version detected"
 msgid "取消"
 msgstr "Cancel"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:85
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
 msgid "变换"
 msgstr "Transform"
 
@@ -758,6 +766,10 @@ msgstr "Experimental fast preview"
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:45
 msgid "宽度"
 msgstr "Width"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+msgid "对比度："
+msgstr "Contrast:"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:155
 msgid "对话"
@@ -1029,11 +1041,11 @@ msgstr "Play sound effect"
 msgid "播放视频"
 msgstr "Play video"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:120
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
 msgid "故障电影滤镜"
 msgstr "Glitch film filter"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:103
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:117
 msgid "效果"
 msgstr "Effect"
 
@@ -1196,7 +1208,7 @@ msgstr "Voiceover mode"
 msgid "旁白模式，无角色名"
 msgstr "Voiceover mode, no role name"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
 msgid "旋转角度："
 msgstr "Rotation angle:"
 
@@ -1462,7 +1474,7 @@ msgstr "Game configuration"
 msgid "源代码"
 msgstr "Source code"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:116
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:157
 msgid "滤镜"
 msgstr "Filter"
 
@@ -1470,7 +1482,7 @@ msgstr "Filter"
 msgid "点击或拖拽文件至此上传"
 msgstr "Click or drag file to this area to upload"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
 msgid "点状电影滤镜"
 msgstr "Dot film filter"
 
@@ -1568,13 +1580,13 @@ msgstr "Figure file"
 msgid "简体中文"
 msgstr "Simplified Chinese"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
+msgid "红色（0-255）："
+msgstr "Red (0-255):"
+
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
 msgid "紧急回避"
 msgstr "Emergency Evasion"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "Traditional Chinese"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1612,6 +1624,10 @@ msgstr "Absolutely"
 #~ msgid "继承模式"
 #~ msgstr ""
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+msgid "绿色（0-255）："
+msgstr "Green (0-255)"
+
 #: src/components/IconCreator/IconCreator.tsx:643
 msgid "编辑图标"
 msgstr "Edit icon"
@@ -1628,14 +1644,18 @@ msgstr "Edit game"
 msgid "编辑组件"
 msgstr "Edit component"
 
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
+msgid "繁体中文"
+msgstr "Traditional Chinese"
+
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:94
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
 msgid "缩放"
 msgstr "Scale"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:117
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:158
 msgid "老电影滤镜"
 msgstr "Old film filter"
 
@@ -1729,6 +1749,10 @@ msgstr "Get character input from user"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:244
 msgid "获取输入"
 msgstr "Get input"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+msgid "蓝色（0-255）："
+msgstr "Blue (0-255):"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:56
 msgid "行脚本"
@@ -1986,7 +2010,7 @@ msgstr "Selection Button Wrapper"
 msgid "选项菜单"
 msgstr "Option Menu"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
 msgid "透明度（0-1）："
 msgstr "Opacity (0-1):"
 
@@ -2091,11 +2115,19 @@ msgstr "Preview icon"
 msgid "颜色"
 msgstr "Color"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:130
+msgid "颜色调整"
+msgstr "Color adjustment"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+msgid "饱和度："
+msgstr "Saturation:"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:48
 msgid "高度"
 msgstr "Height"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:112
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:126
 msgid "高斯模糊："
 msgstr "Gaussian Blur:"
 
@@ -2103,18 +2135,28 @@ msgstr "Gaussian Blur:"
 msgid "默认"
 msgstr "Default"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:86
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:90
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:112
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:100
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:126
 msgid "默认值0"
 msgstr "Default Value is 0"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:95
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
 msgid "默认值1"
 msgstr "Default Value is 1"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+msgid "默认值255"
+msgstr "Default Value is 255"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
 msgid "默认语言"

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -2140,7 +2140,7 @@ msgstr "Default"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:126
 msgid "默认值0"
-msgstr "Default Value is 0"
+msgstr "Default 0"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
@@ -2150,13 +2150,13 @@ msgstr "Default Value is 0"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:142
 msgid "默认值1"
-msgstr "Default Value is 1"
+msgstr "Default 1"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:153
 msgid "默认值255"
-msgstr "Default Value is 255"
+msgstr "Default 255"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
 msgid "默认语言"

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -122,7 +122,7 @@ msgstr "playEffect: Choose a sound effect file;"
 msgid "playVideo:选择视频文件;"
 msgstr "playVideo: Choose a video file;"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:164
 msgid "RGB电影滤镜"
 msgstr "RGB film"
 
@@ -272,7 +272,7 @@ msgstr "Main Style"
 msgid "主页"
 msgstr "WebGAL Home"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:133
 msgid "亮度："
 msgstr "Brightness:"
 
@@ -280,7 +280,7 @@ msgstr "Brightness:"
 msgid "代码编辑器"
 msgstr "Code Editor"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:142
 msgid "伽马值："
 msgstr "Gamma:"
 
@@ -386,7 +386,7 @@ msgstr "Stop the BGM"
 msgid "像素"
 msgstr "pixel"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:165
 msgid "光辉电影滤镜"
 msgstr "Godray film"
 
@@ -577,7 +577,7 @@ msgstr "Unit milliseconds. 0~ valid"
 msgid "单行注释"
 msgstr "Single line comment"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
 msgid "反射电影滤镜"
 msgstr "Reflection film filter"
 
@@ -767,7 +767,7 @@ msgstr "Experimental fast preview"
 msgid "宽度"
 msgstr "Width"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:136
 msgid "对比度："
 msgstr "Contrast:"
 
@@ -1041,7 +1041,7 @@ msgstr "Play sound effect"
 msgid "播放视频"
 msgstr "Play video"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
 msgid "故障电影滤镜"
 msgstr "Glitch film filter"
 
@@ -1474,7 +1474,7 @@ msgstr "Game configuration"
 msgid "源代码"
 msgstr "Source code"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:157
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
 msgid "滤镜"
 msgstr "Filter"
 
@@ -1482,7 +1482,7 @@ msgstr "Filter"
 msgid "点击或拖拽文件至此上传"
 msgstr "Click or drag file to this area to upload"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
 msgid "点状电影滤镜"
 msgstr "Dot film filter"
 
@@ -1580,13 +1580,17 @@ msgstr "Figure file"
 msgid "简体中文"
 msgstr "Simplified Chinese"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
-msgid "红色（0-255）："
-msgstr "Red (0-255):"
-
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
 msgid "紧急回避"
 msgstr "Emergency Evasion"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
+msgid "繁体中文"
+msgstr "Traditional Chinese"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
+msgid "红色（0-255）："
+msgstr "Red (0-255):"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1624,7 +1628,7 @@ msgstr "Absolutely"
 #~ msgid "继承模式"
 #~ msgstr ""
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 msgid "绿色（0-255）："
 msgstr "Green (0-255)"
 
@@ -1644,10 +1648,6 @@ msgstr "Edit game"
 msgid "编辑组件"
 msgstr "Edit component"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "Traditional Chinese"
-
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
@@ -1655,7 +1655,7 @@ msgstr "Traditional Chinese"
 msgid "缩放"
 msgstr "Scale"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:158
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
 msgid "老电影滤镜"
 msgstr "Old film filter"
 
@@ -1750,7 +1750,7 @@ msgstr "Get character input from user"
 msgid "获取输入"
 msgstr "Get input"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:153
 msgid "蓝色（0-255）："
 msgstr "Blue (0-255):"
 
@@ -2119,7 +2119,7 @@ msgstr "Color"
 msgid "颜色调整"
 msgstr "Color adjustment"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
 msgid "饱和度："
 msgstr "Saturation:"
 
@@ -2145,16 +2145,16 @@ msgstr "Default Value is 0"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:133
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:136
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:142
 msgid "默认值1"
 msgstr "Default Value is 1"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:153
 msgid "默认值255"
 msgstr "Default Value is 255"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -122,7 +122,7 @@ msgstr "playEffect: 効果音を選択;"
 msgid "playVideo:选择视频文件;"
 msgstr "playVideo: 動画を選択;"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:121
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
 msgid "RGB电影滤镜"
 msgstr "RGB映画"
 
@@ -160,19 +160,19 @@ msgstr "WebGAL Classic"
 msgid "WebGAL Standard"
 msgstr "WebGAL Standard"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:86
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:100
 msgid "X轴位移："
 msgstr " X軸位移："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:95
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
 msgid "X轴缩放："
 msgstr " X軸スケール："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:90
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
 msgid "Y轴位移："
 msgstr " Y軸位移："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
 msgid "Y轴缩放："
 msgstr " Y軸スケール："
 
@@ -272,9 +272,17 @@ msgstr "メインスタイル"
 msgid "主页"
 msgstr "WebGALホーム"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+msgid "亮度："
+msgstr "輝度:"
+
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:97
 msgid "代码编辑器"
 msgstr "コードエディタ"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+msgid "伽马值："
+msgstr "ガンマ:"
 
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:137
 msgid "你已启用实验性快速预览，该功能将大幅提升实时预览效率，但可能出现异常。特别提示：不要在上一次实时预览跳转还没有完全结束时（尤其是有动画没有结束时）再次跳转。"
@@ -378,7 +386,7 @@ msgstr "BGMを停止"
 msgid "像素"
 msgstr "ピクセル"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
 msgid "光辉电影滤镜"
 msgstr "ゴッドレイ映画"
 
@@ -569,7 +577,7 @@ msgstr "ミリ秒単位。 0~ 有効"
 msgid "单行注释"
 msgstr "一行コメント"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:119
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
 msgid "反射电影滤镜"
 msgstr "反射映画"
 
@@ -584,7 +592,7 @@ msgstr "新しいバージョンが検出されました"
 msgid "取消"
 msgstr "キャンセル"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:85
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
 msgid "变换"
 msgstr "トランスフォーム"
 
@@ -758,6 +766,10 @@ msgstr "実験的な高速プレビュー"
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:45
 msgid "宽度"
 msgstr "幅"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+msgid "对比度："
+msgstr "コントラスト比:"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:155
 msgid "对话"
@@ -1029,11 +1041,11 @@ msgstr "効果音を再生"
 msgid "播放视频"
 msgstr "動画の再生"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:120
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
 msgid "故障电影滤镜"
 msgstr "グリッチ映画"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:103
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:117
 msgid "效果"
 msgstr "エフェクト"
 
@@ -1196,7 +1208,7 @@ msgstr "ナレーションモード"
 msgid "旁白模式，无角色名"
 msgstr "キャラクター名は設定不可"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
 msgid "旋转角度："
 msgstr "回転："
 
@@ -1462,7 +1474,7 @@ msgstr "ゲーム構成"
 msgid "源代码"
 msgstr "ソースコード"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:116
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:157
 msgid "滤镜"
 msgstr "フィルター"
 
@@ -1470,7 +1482,7 @@ msgstr "フィルター"
 msgid "点击或拖拽文件至此上传"
 msgstr "ここまでクリックかドラッグでアップロードします"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
 msgid "点状电影滤镜"
 msgstr "ドット映画"
 
@@ -1568,13 +1580,13 @@ msgstr "立ち絵ファイル"
 msgid "简体中文"
 msgstr "簡体字中国語"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
+msgid "红色（0-255）："
+msgstr "赤(0-255):"
+
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
 msgid "紧急回避"
 msgstr "緊急回避"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "繁体字中国語"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1612,6 +1624,10 @@ msgstr "絶対"
 #~ msgid "继承模式"
 #~ msgstr ""
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+msgid "绿色（0-255）："
+msgstr "緑(0-255):"
+
 #: src/components/IconCreator/IconCreator.tsx:643
 msgid "编辑图标"
 msgstr "編集アイコン"
@@ -1628,14 +1644,18 @@ msgstr "ゲームの編集"
 msgid "编辑组件"
 msgstr "コンポーネントの編集"
 
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
+msgid "繁体中文"
+msgstr "繁体字中国語"
+
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:94
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
 msgid "缩放"
 msgstr "スケール"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:117
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:158
 msgid "老电影滤镜"
 msgstr "古い映画"
 
@@ -1729,6 +1749,10 @@ msgstr "ユーザーからの文字入力を取得"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:244
 msgid "获取输入"
 msgstr "入力を取得"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+msgid "蓝色（0-255）："
+msgstr "青(0-255):"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:56
 msgid "行脚本"
@@ -1986,7 +2010,7 @@ msgstr "選択肢ボタン外層"
 msgid "选项菜单"
 msgstr "オプションメニュー"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
 msgid "透明度（0-1）："
 msgstr "透明度（０－１）："
 
@@ -2091,11 +2115,19 @@ msgstr "プレビューアイコン"
 msgid "颜色"
 msgstr "色"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:130
+msgid "颜色调整"
+msgstr "色調節"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+msgid "饱和度："
+msgstr "彩度:"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:48
 msgid "高度"
 msgstr "高さ"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:112
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:126
 msgid "高斯模糊："
 msgstr "ぼかし："
 
@@ -2103,18 +2135,28 @@ msgstr "ぼかし："
 msgid "默认"
 msgstr "デフォルト"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:86
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:90
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:112
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:100
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:126
 msgid "默认值0"
 msgstr "デフォルト値は0"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:95
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
 msgid "默认值1"
 msgstr "デフォルト値は1"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+msgid "默认值255"
+msgstr "デフォルト値は255"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
 msgid "默认语言"

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -122,7 +122,7 @@ msgstr "playEffect: 効果音を選択;"
 msgid "playVideo:选择视频文件;"
 msgstr "playVideo: 動画を選択;"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:164
 msgid "RGB电影滤镜"
 msgstr "RGB映画"
 
@@ -272,7 +272,7 @@ msgstr "メインスタイル"
 msgid "主页"
 msgstr "WebGALホーム"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:133
 msgid "亮度："
 msgstr "輝度:"
 
@@ -280,7 +280,7 @@ msgstr "輝度:"
 msgid "代码编辑器"
 msgstr "コードエディタ"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:142
 msgid "伽马值："
 msgstr "ガンマ:"
 
@@ -386,7 +386,7 @@ msgstr "BGMを停止"
 msgid "像素"
 msgstr "ピクセル"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:165
 msgid "光辉电影滤镜"
 msgstr "ゴッドレイ映画"
 
@@ -577,7 +577,7 @@ msgstr "ミリ秒単位。 0~ 有効"
 msgid "单行注释"
 msgstr "一行コメント"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
 msgid "反射电影滤镜"
 msgstr "反射映画"
 
@@ -767,7 +767,7 @@ msgstr "実験的な高速プレビュー"
 msgid "宽度"
 msgstr "幅"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:136
 msgid "对比度："
 msgstr "コントラスト比:"
 
@@ -1041,7 +1041,7 @@ msgstr "効果音を再生"
 msgid "播放视频"
 msgstr "動画の再生"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
 msgid "故障电影滤镜"
 msgstr "グリッチ映画"
 
@@ -1474,7 +1474,7 @@ msgstr "ゲーム構成"
 msgid "源代码"
 msgstr "ソースコード"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:157
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
 msgid "滤镜"
 msgstr "フィルター"
 
@@ -1482,7 +1482,7 @@ msgstr "フィルター"
 msgid "点击或拖拽文件至此上传"
 msgstr "ここまでクリックかドラッグでアップロードします"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
 msgid "点状电影滤镜"
 msgstr "ドット映画"
 
@@ -1580,13 +1580,17 @@ msgstr "立ち絵ファイル"
 msgid "简体中文"
 msgstr "簡体字中国語"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
-msgid "红色（0-255）："
-msgstr "赤(0-255):"
-
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
 msgid "紧急回避"
 msgstr "緊急回避"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
+msgid "繁体中文"
+msgstr "繁体字中国語"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
+msgid "红色（0-255）："
+msgstr "赤(0-255):"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1624,7 +1628,7 @@ msgstr "絶対"
 #~ msgid "继承模式"
 #~ msgstr ""
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 msgid "绿色（0-255）："
 msgstr "緑(0-255):"
 
@@ -1644,10 +1648,6 @@ msgstr "ゲームの編集"
 msgid "编辑组件"
 msgstr "コンポーネントの編集"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "繁体字中国語"
-
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
@@ -1655,7 +1655,7 @@ msgstr "繁体字中国語"
 msgid "缩放"
 msgstr "スケール"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:158
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
 msgid "老电影滤镜"
 msgstr "古い映画"
 
@@ -1750,7 +1750,7 @@ msgstr "ユーザーからの文字入力を取得"
 msgid "获取输入"
 msgstr "入力を取得"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:153
 msgid "蓝色（0-255）："
 msgstr "青(0-255):"
 
@@ -2119,7 +2119,7 @@ msgstr "色"
 msgid "颜色调整"
 msgstr "色調節"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
 msgid "饱和度："
 msgstr "彩度:"
 
@@ -2145,16 +2145,16 @@ msgstr "デフォルト値は0"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:133
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:136
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:142
 msgid "默认值1"
 msgstr "デフォルト値は1"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:153
 msgid "默认值255"
 msgstr "デフォルト値は255"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -138,7 +138,7 @@ msgstr "playEffect:选择效果音文件;"
 msgid "playVideo:选择视频文件;"
 msgstr "playVideo:选择视频文件;"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:121
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
 msgid "RGB电影滤镜"
 msgstr "RGB电影滤镜"
 
@@ -176,19 +176,19 @@ msgstr "WebGAL Classic"
 msgid "WebGAL Standard"
 msgstr "WebGAL Standard"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:86
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:100
 msgid "X轴位移："
 msgstr "X轴位移："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:95
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
 msgid "X轴缩放："
 msgstr "X轴缩放："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:90
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
 msgid "Y轴位移："
 msgstr "Y轴位移："
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
 msgid "Y轴缩放："
 msgstr "Y轴缩放："
 
@@ -288,9 +288,17 @@ msgstr "主要样式"
 msgid "主页"
 msgstr "主页"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+msgid "亮度："
+msgstr "亮度："
+
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:97
 msgid "代码编辑器"
 msgstr "代码编辑器"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+msgid "伽马值："
+msgstr "伽马值："
 
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:137
 msgid "你已启用实验性快速预览，该功能将大幅提升实时预览效率，但可能出现异常。特别提示：不要在上一次实时预览跳转还没有完全结束时（尤其是有动画没有结束时）再次跳转。"
@@ -398,7 +406,7 @@ msgstr "停止 BGM"
 msgid "像素"
 msgstr "像素"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
 msgid "光辉电影滤镜"
 msgstr "光辉电影滤镜"
 
@@ -589,7 +597,7 @@ msgstr "单位毫秒。 0~ 有效"
 msgid "单行注释"
 msgstr "单行注释"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:119
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
 msgid "反射电影滤镜"
 msgstr "反射电影滤镜"
 
@@ -604,7 +612,7 @@ msgstr "发现新版本"
 msgid "取消"
 msgstr "取消"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:85
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
 msgid "变换"
 msgstr "变换"
 
@@ -778,6 +786,10 @@ msgstr "实验性快速预览"
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:45
 msgid "宽度"
 msgstr "宽度"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+msgid "对比度："
+msgstr "对比度："
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:155
 msgid "对话"
@@ -1049,11 +1061,11 @@ msgstr "播放效果音"
 msgid "播放视频"
 msgstr "播放视频"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:120
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
 msgid "故障电影滤镜"
 msgstr "故障电影滤镜"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:103
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:117
 msgid "效果"
 msgstr "效果"
 
@@ -1216,7 +1228,7 @@ msgstr "旁白模式"
 msgid "旁白模式，无角色名"
 msgstr "旁白模式，无角色名"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
 msgid "旋转角度："
 msgstr "旋转角度："
 
@@ -1482,7 +1494,7 @@ msgstr "游戏配置"
 msgid "源代码"
 msgstr "源代码"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:116
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:157
 msgid "滤镜"
 msgstr "滤镜"
 
@@ -1490,7 +1502,7 @@ msgstr "滤镜"
 msgid "点击或拖拽文件至此上传"
 msgstr "点击或拖拽文件至此上传"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
 msgid "点状电影滤镜"
 msgstr "点状电影滤镜"
 
@@ -1596,13 +1608,13 @@ msgstr "立绘文件"
 msgid "简体中文"
 msgstr "简体中文"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
+msgid "红色（0-255）："
+msgstr "红色（0-255）："
+
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
 msgid "紧急回避"
 msgstr "紧急回避"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "繁体中文"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1640,6 +1652,10 @@ msgstr "绝对"
 #~ msgid "继承模式"
 #~ msgstr "继承模式"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+msgid "绿色（0-255）："
+msgstr "绿色（0-255）："
+
 #: src/components/IconCreator/IconCreator.tsx:643
 msgid "编辑图标"
 msgstr "编辑图标"
@@ -1656,14 +1672,18 @@ msgstr "编辑游戏"
 msgid "编辑组件"
 msgstr "编辑组件"
 
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
+msgid "繁体中文"
+msgstr "繁体中文"
+
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:94
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
 msgid "缩放"
 msgstr "缩放"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:117
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:158
 msgid "老电影滤镜"
 msgstr "老电影滤镜"
 
@@ -1757,6 +1777,10 @@ msgstr "获取来自用户的字符输入"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:244
 msgid "获取输入"
 msgstr "获取输入"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+msgid "蓝色（0-255）："
+msgstr "蓝色（0-255）："
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:56
 msgid "行脚本"
@@ -2014,7 +2038,7 @@ msgstr "选项按钮外层"
 msgid "选项菜单"
 msgstr "选项菜单"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
 msgid "透明度（0-1）："
 msgstr "透明度（0-1）："
 
@@ -2119,11 +2143,19 @@ msgstr "预览图标"
 msgid "颜色"
 msgstr "颜色"
 
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:130
+msgid "颜色调整"
+msgstr "颜色调整"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+msgid "饱和度："
+msgstr "饱和度："
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:48
 msgid "高度"
 msgstr "高度"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:112
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:126
 msgid "高斯模糊："
 msgstr "高斯模糊："
 
@@ -2131,18 +2163,28 @@ msgstr "高斯模糊："
 msgid "默认"
 msgstr "默认"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:86
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:90
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:108
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:112
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:100
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:122
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:126
 msgid "默认值0"
 msgstr "默认值0"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:95
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:99
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:104
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
 msgid "默认值1"
 msgstr "默认值1"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+msgid "默认值255"
+msgstr "默认值255"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
 msgid "默认语言"

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -138,7 +138,7 @@ msgstr "playEffect:选择效果音文件;"
 msgid "playVideo:选择视频文件;"
 msgstr "playVideo:选择视频文件;"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:164
 msgid "RGB电影滤镜"
 msgstr "RGB电影滤镜"
 
@@ -288,7 +288,7 @@ msgstr "主要样式"
 msgid "主页"
 msgstr "主页"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:133
 msgid "亮度："
 msgstr "亮度："
 
@@ -296,7 +296,7 @@ msgstr "亮度："
 msgid "代码编辑器"
 msgstr "代码编辑器"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:142
 msgid "伽马值："
 msgstr "伽马值："
 
@@ -406,7 +406,7 @@ msgstr "停止 BGM"
 msgid "像素"
 msgstr "像素"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:165
 msgid "光辉电影滤镜"
 msgstr "光辉电影滤镜"
 
@@ -597,7 +597,7 @@ msgstr "单位毫秒。 0~ 有效"
 msgid "单行注释"
 msgstr "单行注释"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:162
 msgid "反射电影滤镜"
 msgstr "反射电影滤镜"
 
@@ -787,7 +787,7 @@ msgstr "实验性快速预览"
 msgid "宽度"
 msgstr "宽度"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:136
 msgid "对比度："
 msgstr "对比度："
 
@@ -1061,7 +1061,7 @@ msgstr "播放效果音"
 msgid "播放视频"
 msgstr "播放视频"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:163
 msgid "故障电影滤镜"
 msgstr "故障电影滤镜"
 
@@ -1494,7 +1494,7 @@ msgstr "游戏配置"
 msgid "源代码"
 msgstr "源代码"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:157
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
 msgid "滤镜"
 msgstr "滤镜"
 
@@ -1502,7 +1502,7 @@ msgstr "滤镜"
 msgid "点击或拖拽文件至此上传"
 msgstr "点击或拖拽文件至此上传"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:159
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:161
 msgid "点状电影滤镜"
 msgstr "点状电影滤镜"
 
@@ -1608,13 +1608,17 @@ msgstr "立绘文件"
 msgid "简体中文"
 msgstr "简体中文"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
-msgid "红色（0-255）："
-msgstr "红色（0-255）："
-
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
 msgid "紧急回避"
 msgstr "紧急回避"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
+msgid "繁体中文"
+msgstr "繁体中文"
+
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
+msgid "红色（0-255）："
+msgstr "红色（0-255）："
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1652,7 +1656,7 @@ msgstr "绝对"
 #~ msgid "继承模式"
 #~ msgstr "继承模式"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 msgid "绿色（0-255）："
 msgstr "绿色（0-255）："
 
@@ -1672,10 +1676,6 @@ msgstr "编辑游戏"
 msgid "编辑组件"
 msgstr "编辑组件"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "繁体中文"
-
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
@@ -1683,7 +1683,7 @@ msgstr "繁体中文"
 msgid "缩放"
 msgstr "缩放"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:158
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:160
 msgid "老电影滤镜"
 msgstr "老电影滤镜"
 
@@ -1778,7 +1778,7 @@ msgstr "获取来自用户的字符输入"
 msgid "获取输入"
 msgstr "获取输入"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:153
 msgid "蓝色（0-255）："
 msgstr "蓝色（0-255）："
 
@@ -2147,7 +2147,7 @@ msgstr "颜色"
 msgid "颜色调整"
 msgstr "颜色调整"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
 msgid "饱和度："
 msgstr "饱和度："
 
@@ -2173,16 +2173,16 @@ msgstr "默认值0"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:109
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:113
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:118
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:132
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:135
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:138
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:133
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:136
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:142
 msgid "默认值1"
 msgstr "默认值1"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:146
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:149
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:152
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:153
 msgid "默认值255"
 msgstr "默认值255"
 

--- a/packages/origine2/src/pages/editor/GraphicalEditor/components/EffectEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/components/EffectEditor.tsx
@@ -27,6 +27,13 @@ export function EffectEditor(props:{
   const alpha = useValue(effectObject?.alpha ?? '');
   const rotation = useValue(effectObject?.rotation ?? '');
   const blur = useValue(effectObject?.blur ?? '');
+  const brightness = useValue(effectObject?.brightness ?? '');
+  const contrast = useValue(effectObject?.contrast ?? '');
+  const saturation = useValue(effectObject?.saturation ?? '');
+  const gamma = useValue(effectObject?.gamma ?? '');
+  const colorRed = useValue(effectObject?.colorRed ?? '');
+  const colorGreen = useValue(effectObject?.colorGreen ?? '');
+  const colorBlue = useValue(effectObject?.colorBlue ?? '');
   const oldFilm = useValue(effectObject?.oldFilm ?? '');
   const dotFilm = useValue(effectObject?.dotFilm ?? '');
   const reflectionFilm = useValue(effectObject?.reflectionFilm ?? '');
@@ -45,6 +52,13 @@ export function EffectEditor(props:{
     if(!isNaN(Number(alpha.value))&&alpha.value!==''){result.alpha = Number(alpha.value);};
     if(!isNaN(Number(rotation.value))&&rotation.value!==''){result.rotation = Number(rotation.value);};
     if(!isNaN(Number(blur.value))&&blur.value!==''){result.blur = Number(blur.value);};
+    if(!isNaN(Number(brightness.value))&&brightness.value!==''){result.brightness = Number(brightness.value);};
+    if(!isNaN(Number(contrast.value))&&contrast.value!==''){result.contrast = Number(contrast.value);};
+    if(!isNaN(Number(saturation.value))&&saturation.value!==''){result.saturation = Number(saturation.value);};
+    if(!isNaN(Number(gamma.value))&&gamma.value!==''){result.gamma = Number(gamma.value);};
+    if(!isNaN(Number(colorRed.value))&&colorRed.value!==''){result.colorRed = Number(colorRed.value);};
+    if(!isNaN(Number(colorGreen.value))&&colorGreen.value!==''){result.colorGreen = Number(colorGreen.value);};
+    if(!isNaN(Number(colorBlue.value))&&colorBlue.value!==''){result.colorBlue = Number(colorBlue.value);};
     if(oldFilm.value){result.oldFilm = 1;};
     if(dotFilm.value){result.dotFilm = 1;};
     if(reflectionFilm.value){result.reflectionFilm = 1;};
@@ -113,7 +127,34 @@ export function EffectEditor(props:{
         blur.set(data.value);
       }} onBlur={submit} style={{width: '140px'}}/>
     </CommonOptions>
-    <CommonOptions key={4} title={t`滤镜`}>
+    <CommonOptions key={4} title={t`颜色调整`}>
+      <div>
+        {t`亮度：`}<Input value={brightness.value} placeholder={t`默认值1`} onChange={(_, data) => {
+          brightness.set(data.value);
+        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+        {t`对比度：`}<Input value={contrast.value} placeholder={t`默认值1`} onChange={(_, data) => {
+          contrast.set(data.value);
+        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+        {t`饱和度：`}<Input value={saturation.value} placeholder={t`默认值1`} onChange={(_, data) => {
+          saturation.set(data.value);
+        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+        {t`伽马值：`}<Input value={gamma.value} placeholder={t`默认值1`} onChange={(_, data) => {
+          gamma.set(data.value);
+        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+      </div>
+      <div style={{marginTop: 5}}>
+        {t`红色（0-255）：`}<Input value={colorRed.value} placeholder={t`默认值255`} onChange={(_, data) => {
+          colorRed.set(data.value);
+        }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
+        {t`绿色（0-255）：`}<Input value={colorGreen.value} placeholder={t`默认值255`} onChange={(_, data) => {
+          colorGreen.set(data.value);
+        }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
+        {t`蓝色（0-255）：`}<Input value={colorBlue.value} placeholder={t`默认值255`} onChange={(_, data) => {
+          colorBlue.set(data.value);
+        }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
+      </div>
+    </CommonOptions>
+    <CommonOptions key={5} title={t`滤镜`}>
       <Checkbox checked={oldFilm.value === 1} onChange={(_, data) => { oldFilm.set(data.checked ? 1 : 0); submit(); }} label={t`老电影滤镜`} />{'\u00a0'}
       <Checkbox checked={dotFilm.value === 1} onChange={(_, data) => { dotFilm.set(data.checked ? 1 : 0); submit(); }} label={t`点状电影滤镜`}/>{'\u00a0'}
       <Checkbox checked={reflectionFilm.value === 1} onChange={(_, data) => { reflectionFilm.set(data.checked ? 1 : 0); submit(); }} label={t`反射电影滤镜`}/>{'\u00a0'}

--- a/packages/origine2/src/pages/editor/GraphicalEditor/components/EffectEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/components/EffectEditor.tsx
@@ -129,29 +129,31 @@ export function EffectEditor(props:{
     </CommonOptions>
     <CommonOptions key={4} title={t`颜色调整`}>
       <div>
-        {t`亮度：`}<Input value={brightness.value} placeholder={t`默认值1`} onChange={(_, data) => {
-          brightness.set(data.value);
-        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
-        {t`对比度：`}<Input value={contrast.value} placeholder={t`默认值1`} onChange={(_, data) => {
-          contrast.set(data.value);
-        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
-        {t`饱和度：`}<Input value={saturation.value} placeholder={t`默认值1`} onChange={(_, data) => {
-          saturation.set(data.value);
-        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
-        {t`伽马值：`}<Input value={gamma.value} placeholder={t`默认值1`} onChange={(_, data) => {
-          gamma.set(data.value);
-        }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
-      </div>
-      <div style={{marginTop: 5}}>
-        {t`红色（0-255）：`}<Input value={colorRed.value} placeholder={t`默认值255`} onChange={(_, data) => {
-          colorRed.set(data.value);
-        }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
-        {t`绿色（0-255）：`}<Input value={colorGreen.value} placeholder={t`默认值255`} onChange={(_, data) => {
-          colorGreen.set(data.value);
-        }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
-        {t`蓝色（0-255）：`}<Input value={colorBlue.value} placeholder={t`默认值255`} onChange={(_, data) => {
-          colorBlue.set(data.value);
-        }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
+        <div>
+          {t`亮度：`}<Input value={brightness.value} placeholder={t`默认值1`} onChange={(_, data) => {
+            brightness.set(data.value);
+          }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+          {t`对比度：`}<Input value={contrast.value} placeholder={t`默认值1`} onChange={(_, data) => {
+            contrast.set(data.value);
+          }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+          {t`饱和度：`}<Input value={saturation.value} placeholder={t`默认值1`} onChange={(_, data) => {
+            saturation.set(data.value);
+          }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+          {t`伽马值：`}<Input value={gamma.value} placeholder={t`默认值1`} onChange={(_, data) => {
+            gamma.set(data.value);
+          }} onBlur={submit} style={{width: '100px'}}/>{'\u00a0'}
+        </div>
+        <div style={{marginTop: 5}}>
+          {t`红色（0-255）：`}<Input value={colorRed.value} placeholder={t`默认值255`} onChange={(_, data) => {
+            colorRed.set(data.value);
+          }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
+          {t`绿色（0-255）：`}<Input value={colorGreen.value} placeholder={t`默认值255`} onChange={(_, data) => {
+            colorGreen.set(data.value);
+          }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
+          {t`蓝色（0-255）：`}<Input value={colorBlue.value} placeholder={t`默认值255`} onChange={(_, data) => {
+            colorBlue.set(data.value);
+          }} onBlur={submit} style={{width: '120px'}}/>{'\u00a0'}
+        </div>
       </div>
     </CommonOptions>
     <CommonOptions key={5} title={t`滤镜`}>

--- a/packages/origine2/src/pages/editor/GraphicalEditor/components/commonOption.module.scss
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/components/commonOption.module.scss
@@ -28,7 +28,8 @@
 
 .content {
   flex: 1;
-  display: flex;
+  display: block;
   justify-content: left;
   align-items: center;
+  align-content: center;
 }

--- a/packages/origine2/src/pages/editor/GraphicalEditor/components/commonOption.module.scss
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/components/commonOption.module.scss
@@ -28,8 +28,7 @@
 
 .content {
   flex: 1;
-  display: block;
+  display: flex;
   justify-content: left;
   align-items: center;
-  align-content: center;
 }


### PR DESCRIPTION
# 介绍
支持颜色调整命令
__**注**: 此 PR 以 OpenWebGAL/WebGAL#676 为前置要求__
![image](https://github.com/user-attachments/assets/5d6bd0ed-6dfa-4721-8668-4813989adc82)

# 更改
- 在`切换立绘` `切换背景` `设置效果` 中打开 `效果编辑器`, 可调节颜色调整选项
- 已完成日文和英文本地化, 但均为机翻