### PR TITLE
fix: 防止触发mac sip编译问题Fix

### DIFF
--- a/release-mac.sh
+++ b/release-mac.sh
@@ -72,10 +72,12 @@ echo './WebGAL_Terre' >> run-webgal-on-mac.command
 chmod +x run-webgal-on-mac.command
 chmod +x WebGAL/WebGAL_Terre
 
-# readme
-echo '你需要在本目录下执行 "chmod -R +x ."，并且使用 run-webgal-on-mac.command 脚本才能正确使用 WebGAL Terre' >> readme.txt
-echo 'You need to execute "chmod -R +x ." in this directory, and use run-webgal-on-mac.command to use WebGAL Terre correctly' >> readme.txt
-echo 'WebGAL Terre を正しく使用するには、このディレクトリで「chmod -R +x .」を実行し、run-webgal-on-mac.command スクリプトを使用する必要があります。' >> readme.txt
+# readme 多语言提示（现阶段说明）
+echo '请直接运行对应平台的脚本文件，即可完成 WebGAL Terre 的启动工作。' > readme.txt
+echo 'Simply run the script for your platform to complete the startup of WebGAL Terre.' >> readme.txt
+echo '対応するプラットフォーム用のスクリプトを実行するだけで、WebGAL Terre の起動が完了します。' >> readme.txt
+
+
 chmod -R +x .
 
 echo "WebGAL Terre is now ready to be deployed."

--- a/release-mac.sh
+++ b/release-mac.sh
@@ -73,9 +73,9 @@ chmod +x run-webgal-on-mac.command
 chmod +x WebGAL/WebGAL_Terre
 
 # readme 多语言提示（现阶段说明）
-echo '请直接运行对应平台的脚本文件，即可完成 WebGAL Terre 的启动工作。' > readme.txt
-echo 'Simply run the script for your platform to complete the startup of WebGAL Terre.' >> readme.txt
-echo '対応するプラットフォーム用のスクリプトを実行するだけで、WebGAL Terre の起動が完了します。' >> readme.txt
+echo '你需要为可执行文件设置正确的权限，并使用 run-webgal-on-mac.command 脚本才能正确使用 WebGAL Terre' > readme.txt
+echo 'You need to set the correct permissions for the executable file and use the run-webgal-on-mac.command script to use WebGAL Terre correctly' >> readme.txt
+echo 'WebGAL Terreを正しく使用するには、実行可能ファイルに正しいパーミッションを設定し、run-webgal-on-mac.command スクリプトを使用する必要があります。' >> readme.txt
 
 
 echo "WebGAL Terre is now ready to be deployed."

--- a/release-mac.sh
+++ b/release-mac.sh
@@ -70,6 +70,7 @@ echo 'cd "$(dirname "$0")"' >> run-webgal-on-mac.command
 echo 'cd WebGAL' >> run-webgal-on-mac.command
 echo './WebGAL_Terre' >> run-webgal-on-mac.command
 chmod +x run-webgal-on-mac.command
+chmod +x WebGAL/WebGAL_Terre
 
 # readme
 echo '你需要在本目录下执行 "chmod -R +x ."，并且使用 run-webgal-on-mac.command 脚本才能正确使用 WebGAL Terre' >> readme.txt

--- a/release-mac.sh
+++ b/release-mac.sh
@@ -78,6 +78,4 @@ echo 'Simply run the script for your platform to complete the startup of WebGAL 
 echo '対応するプラットフォーム用のスクリプトを実行するだけで、WebGAL Terre の起動が完了します。' >> readme.txt
 
 
-chmod -R +x .
-
 echo "WebGAL Terre is now ready to be deployed."


### PR DESCRIPTION
```markdown
# 🛠 WebGAL 构建权限修复说明（Fix: `Operation not permitted` on .plist）

## 📌 背景（Background）

在 macOS 开发环境下执行构建脚本时，部分用户遇到如下错误：

```

chmod: Unable to change file mode on ./System/Library/...: Operation not permitted

````

这是因为脚本中使用了递归权限修改命令：

```bash
chmod -R +x .
````

而 macOS 的 **System Integrity Protection (SIP)** 机制禁止对 `/System`, `/Library` 等受保护路径下的文件修改权限，哪怕使用 `sudo`。常见受保护文件包括：

* `.plist` 配置文件
* `.app` 应用包中的资源
* `.framework` 框架组件

这些错误并非构建过程本身的 bug，而是 macOS 安全机制导致的权限限制。

---

## 🧪 问题重现（Reproduction）

当你在项目根目录执行以下命令：

```bash
chmod -R +x .
```

如果该目录下包含了从系统路径中复制过来的 `.plist` 文件或 `.app` 文件夹（如 Electron 打包输出），将会出现如下报错：

```
chmod: ...Operation not permitted
```

---

## ✅ 修复方案（Fix）

### ✅ 1. 目录赋权

不再使用危险的递归命令，而是对确实需要执行权限的脚本/程序单独授权：

```bash
chmod +x WebGAL/WebGAL_Terre
```

这条命令已经被确认会对打包结果造成影响，且在 macOS 上引发构建错误。

---

## 🔒 安全建议（Security Notes）

* 请勿尝试通过关闭 SIP（如执行 `csrutil disable`）规避问题；
* 所有构建产物应放在用户空间下，如：

  ```bash
  /Users/<yourname>/Projects/WebGAL/
  ```
* 避免对 `.app`、`.plist`、`.framework`、`.dylib` 等 macOS 原生组件做 `chmod`、`chown` 等操作。

---

## 📝 使用说明（Usage）

构建完成后，执行以下命令确保入口脚本可执行：

```bash
chmod +x WebGAL/WebGAL_Terre
给予构建目录权限 防止  chmod -R +x . 引起文件雪崩式 chmod: ...Operation not permitted
```

---



