### PR TITLE
feat: add canvas resolution configuration

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -22,11 +22,11 @@ msgstr "Comment"
 msgid "%"
 msgstr "%"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:189
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:190
 msgid "<0>应用新的模板</0>"
 msgstr "<0>Apply a new template</0>"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:168
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:169
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>Current template: {currentTemplateName}</0>"
 
@@ -223,9 +223,9 @@ msgstr "Hide the role name"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:140
 #~ msgid "不继承上一句"
-#~ msgstr ""
+#~ msgstr "Do not inherit the previous sentence"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:232
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:233
 msgid "不设定"
 msgstr "Not set"
 
@@ -343,7 +343,7 @@ msgid "保存"
 msgstr "Save"
 
 #: src/components/IconCreator/IconCreator.tsx:635
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:202
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:203
 msgid "修改游戏图标"
 msgstr "Change game icon"
 
@@ -540,7 +540,7 @@ msgid "删除游戏"
 msgstr "Delete game"
 
 #: src/components/Assets/Assets.tsx:276
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:159
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:221
 msgid "刷新"
 msgstr "Refresh"
 
@@ -560,7 +560,7 @@ msgstr "Functional Area"
 msgid "加粗"
 msgstr "Bold"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:111
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:167
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:241
 msgid "动画"
 msgstr "Animation"
@@ -619,12 +619,12 @@ msgstr "Right Align"
 msgid "启动、切换或停止背景音乐的播放"
 msgstr "Start, switch or stop the playback of background music"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:158
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:159
 msgid "启动图"
 msgstr "Startup image"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:212
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:222
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:213
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:223
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:134
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:82
 msgid "启用"
@@ -674,7 +674,7 @@ msgstr "Open in file explorer"
 
 #: src/pages/dashboard/GameElement.tsx:97
 #: src/pages/dashboard/TemplateElement.tsx:91
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:165
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:227
 msgid "在新标签页中预览"
 msgstr "Preview in new tab"
 
@@ -682,8 +682,8 @@ msgstr "Preview in new tab"
 msgid "在这里放置编辑组件"
 msgstr "Place editing components here"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:116
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:172
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:243
 msgid "场景"
 msgstr "Scene"
 
@@ -745,7 +745,7 @@ msgstr "Positioning"
 msgid "实时预览"
 msgstr "Live preview"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:233
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:92
 msgid "实时预览关闭"
 msgstr "Live preview off"
@@ -754,7 +754,7 @@ msgstr "Live preview off"
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "Live preview fast-forwards the game to the edited statement, but with limitations. The effects of statements from previous scenes, such as variables, won't be reflected in the preview."
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:233
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:92
 msgid "实时预览打开"
 msgstr "Live preview on"
@@ -762,6 +762,10 @@ msgstr "Live preview on"
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:128
 msgid "实验性快速预览"
 msgstr "Experimental fast preview"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:246
+msgid "宽"
+msgstr "Width"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:45
 msgid "宽度"
@@ -889,7 +893,7 @@ msgstr "Tiling"
 msgid "应用"
 msgstr "Apply"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:167
 msgid "应用的模板"
 msgstr "Applied template"
 
@@ -910,13 +914,13 @@ msgstr "Open mouth"
 msgid "当前版本"
 msgstr "Current version"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
 msgid "德语"
 msgstr "German"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:142
 #~ msgid "快速执行"
-#~ msgstr ""
+#~ msgstr "Quick execution"
 
 #: src/pages/dashboard/DashBoard.tsx:166
 msgid "忽略此版本"
@@ -1217,7 +1221,7 @@ msgstr "Rotation angle:"
 msgid "无"
 msgstr "None"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
 msgid "日语"
 msgstr "Japanese"
 
@@ -1305,11 +1309,11 @@ msgstr "Title Button List"
 msgid "标题按钮文字"
 msgstr "Title Button Text"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:142
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:143
 msgid "标题背景图片"
 msgstr "Title background image"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:150
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:151
 msgid "标题背景音乐"
 msgstr "Title background music"
 
@@ -1319,7 +1323,7 @@ msgid "根文本长度 (rem)"
 msgstr "Root Font Size (rem)"
 
 #: src/pages/dashboard/DashBoard.tsx:214
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:174
 msgid "模板"
 msgstr "Template"
 
@@ -1357,7 +1361,7 @@ msgstr "This command will end the game"
 msgid "永不换行"
 msgstr "Never wrap"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
 msgid "法语"
 msgstr "French"
 
@@ -1435,17 +1439,17 @@ msgstr "Games"
 msgid "游戏列表"
 msgstr "Game list"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:133
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
 msgid "游戏包名"
 msgstr "Game package name"
 
 #: src/pages/dashboard/Sidebar.tsx:102
 #: src/pages/dashboard/Sidebar.tsx:111
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:121
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:122
 msgid "游戏名称"
 msgstr "Game name"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:195
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:196
 msgid "游戏图标"
 msgstr "Game icon"
 
@@ -1458,15 +1462,15 @@ msgstr "Game control"
 msgid "游戏目录"
 msgstr "Game directory"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:129
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:130
 msgid "游戏简介"
 msgstr "Game description"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:125
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:126
 msgid "游戏识别码"
 msgstr "Game ID"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:122
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:178
 msgid "游戏配置"
 msgstr "Game configuration"
 
@@ -1489,6 +1493,10 @@ msgstr "Dot film filter"
 #: src/pages/editor/Topbar/tabs/AddSentence/AddSentenceTab.tsx:50
 msgid "特殊演出"
 msgstr "Special performance"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:243
+msgid "画布分辨率"
+msgstr "Canvas resolution"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:56
 #: src/pages/editor/GraphicalEditor/SentenceEditor/PlayEffect.tsx:50
@@ -1527,7 +1535,7 @@ msgstr "View"
 msgid "视觉小说编辑，再进化"
 msgstr "Visual novel editing, evolved"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:120
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:176
 msgid "视频"
 msgstr "Video"
 
@@ -1543,12 +1551,12 @@ msgstr "Video options"
 msgid "禁止跳过视频"
 msgstr "Disable skipping video"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:213
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:223
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:214
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:224
 msgid "禁用"
 msgstr "Disabled"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:115
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
 msgid "立绘"
 msgstr "Figure"
 
@@ -1576,23 +1584,19 @@ msgstr "ID of figure illustration"
 msgid "立绘文件"
 msgstr "Figure file"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:233
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
 msgid "简体中文"
 msgstr "Simplified Chinese"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
-msgid "紧急回避"
-msgstr "Emergency Evasion"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "Traditional Chinese"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
 msgid "红色（0-255）："
 msgstr "Red (0-255):"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:208
+msgid "紧急回避"
+msgstr "Emergency Evasion"
+
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:175
 msgid "纹理"
 msgstr "Texture"
 
@@ -1622,11 +1626,11 @@ msgstr "Absolutely"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:140
 #~ msgid "继承上一句"
-#~ msgstr ""
+#~ msgstr "Inherit the previous sentence"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:136
 #~ msgid "继承模式"
-#~ msgstr ""
+#~ msgstr "Inheritance mode"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 msgid "绿色（0-255）："
@@ -1648,6 +1652,10 @@ msgstr "Edit game"
 msgid "编辑组件"
 msgstr "Edit component"
 
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+msgid "繁体中文"
+msgstr "Traditional Chinese"
+
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
@@ -1660,7 +1668,7 @@ msgid "老电影滤镜"
 msgstr "Old film filter"
 
 #: src/components/IconCreator/IconCreator.tsx:696
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:113
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:169
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:64
 msgid "背景"
 msgstr "Background"
@@ -1733,7 +1741,7 @@ msgstr "Custom effect name"
 msgid "舞台对象控制"
 msgstr "Stage object control"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
 msgid "英语"
 msgstr "English"
 
@@ -1859,7 +1867,7 @@ msgstr "This file type does not support preview"
 msgid "语言"
 msgstr "Language"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:121
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:177
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:215
 msgid "语音"
 msgstr "Voice"
@@ -1888,7 +1896,7 @@ msgstr "Call Scene"
 msgid "调用场景，新场景结束后返回父场景"
 msgstr "Call scene, return to parent scene after new scene ends"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:180
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:242
 msgid "资源"
 msgstr "Assets"
 
@@ -2043,7 +2051,7 @@ msgstr "Rename game directory"
 msgid "鉴赏"
 msgstr "Appreciation"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:218
 msgid "鉴赏功能"
 msgstr "Gallery Feature"
 
@@ -2096,7 +2104,7 @@ msgstr "Right"
 msgid "靠左"
 msgstr "Left"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:114
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:170
 msgid "音乐"
 msgstr "Music"
 
@@ -2122,6 +2130,10 @@ msgstr "Color adjustment"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
 msgid "饱和度："
 msgstr "Saturation:"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:252
+msgid "高"
+msgstr "Height"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:48
 msgid "高度"
@@ -2158,7 +2170,7 @@ msgstr "Default 1"
 msgid "默认值255"
 msgstr "Default 255"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:228
 msgid "默认语言"
 msgstr "Default Language"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -22,11 +22,11 @@ msgstr ";コメント"
 msgid "%"
 msgstr "%"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:189
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:190
 msgid "<0>应用新的模板</0>"
 msgstr "<0>新しいテンプレートを適用する</0>"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:168
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:169
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>現在適用中のテンプレート：{currentTemplateName}</0>"
 
@@ -223,9 +223,9 @@ msgstr "キャラクター名は設定不可"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:140
 #~ msgid "不继承上一句"
-#~ msgstr ""
+#~ msgstr "前の文を継承しない"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:232
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:233
 msgid "不设定"
 msgstr "未設定"
 
@@ -343,7 +343,7 @@ msgid "保存"
 msgstr "セーブ"
 
 #: src/components/IconCreator/IconCreator.tsx:635
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:202
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:203
 msgid "修改游戏图标"
 msgstr "ゲームアイコンの変更"
 
@@ -540,7 +540,7 @@ msgid "删除游戏"
 msgstr "ゲームを削除"
 
 #: src/components/Assets/Assets.tsx:276
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:159
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:221
 msgid "刷新"
 msgstr "更新"
 
@@ -560,7 +560,7 @@ msgstr "機能区の表示"
 msgid "加粗"
 msgstr "太字"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:111
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:167
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:241
 msgid "动画"
 msgstr "アニメーション"
@@ -619,12 +619,12 @@ msgstr "右揃え"
 msgid "启动、切换或停止背景音乐的播放"
 msgstr "BGMの再生を開始、切り替え、または停止する"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:158
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:159
 msgid "启动图"
 msgstr "ロゴ"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:212
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:222
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:213
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:223
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:134
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:82
 msgid "启用"
@@ -674,7 +674,7 @@ msgstr "ファイルエクスプローラーで開く"
 
 #: src/pages/dashboard/GameElement.tsx:97
 #: src/pages/dashboard/TemplateElement.tsx:91
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:165
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:227
 msgid "在新标签页中预览"
 msgstr "新しいタブでプレビュー"
 
@@ -682,8 +682,8 @@ msgstr "新しいタブでプレビュー"
 msgid "在这里放置编辑组件"
 msgstr "ここにコンポーネントを配置"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:116
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:172
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:243
 msgid "场景"
 msgstr "シーン"
 
@@ -745,7 +745,7 @@ msgstr "位置決め方法"
 msgid "实时预览"
 msgstr "リアルタイムプレビュー"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:233
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:92
 msgid "实时预览关闭"
 msgstr "リアルタイムプレビューオフ"
@@ -754,7 +754,7 @@ msgstr "リアルタイムプレビューオフ"
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "リアルタイムプレビューはゲームを制限付きで早送りし、以前のシーンの効果はマッピングされません。"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:233
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:92
 msgid "实时预览打开"
 msgstr "リアルタイムプレビューオン"
@@ -762,6 +762,10 @@ msgstr "リアルタイムプレビューオン"
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:128
 msgid "实验性快速预览"
 msgstr "実験的な高速プレビュー"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:246
+msgid "宽"
+msgstr "幅"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:45
 msgid "宽度"
@@ -889,7 +893,7 @@ msgstr "タイリング"
 msgid "应用"
 msgstr "適用"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:167
 msgid "应用的模板"
 msgstr "すでに適用されているテンプレート"
 
@@ -910,13 +914,13 @@ msgstr "開いた口"
 msgid "当前版本"
 msgstr "現在のバージョン"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
 msgid "德语"
 msgstr "ドイツ語"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:142
 #~ msgid "快速执行"
-#~ msgstr ""
+#~ msgstr "迅速な実行"
 
 #: src/pages/dashboard/DashBoard.tsx:166
 msgid "忽略此版本"
@@ -1217,7 +1221,7 @@ msgstr "回転："
 msgid "无"
 msgstr "Null"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
 msgid "日语"
 msgstr "日本語"
 
@@ -1305,11 +1309,11 @@ msgstr "タイトルボタンリスト"
 msgid "标题按钮文字"
 msgstr "タイトルボタンテキスト"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:142
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:143
 msgid "标题背景图片"
 msgstr "タイトルの背景画像"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:150
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:151
 msgid "标题背景音乐"
 msgstr "タイトルのBGM"
 
@@ -1319,7 +1323,7 @@ msgid "根文本长度 (rem)"
 msgstr "ルートテキストの長さ (rem)"
 
 #: src/pages/dashboard/DashBoard.tsx:214
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:174
 msgid "模板"
 msgstr "テンプレート"
 
@@ -1357,7 +1361,7 @@ msgstr "このコマンドはすべてのゲームが終わるときに使用"
 msgid "永不换行"
 msgstr "折り返しなし"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
 msgid "法语"
 msgstr "フランス語"
 
@@ -1435,17 +1439,17 @@ msgstr "ゲーム"
 msgid "游戏列表"
 msgstr "ゲームリスト"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:133
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
 msgid "游戏包名"
 msgstr "パッケージ名"
 
 #: src/pages/dashboard/Sidebar.tsx:102
 #: src/pages/dashboard/Sidebar.tsx:111
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:121
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:122
 msgid "游戏名称"
 msgstr "ゲーム名"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:195
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:196
 msgid "游戏图标"
 msgstr "ゲームアイコン"
 
@@ -1458,15 +1462,15 @@ msgstr "ゲームコントロール"
 msgid "游戏目录"
 msgstr "ゲームディレクトリ"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:129
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:130
 msgid "游戏简介"
 msgstr "ゲーム概要"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:125
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:126
 msgid "游戏识别码"
 msgstr "ゲームID"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:122
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:178
 msgid "游戏配置"
 msgstr "ゲーム構成"
 
@@ -1489,6 +1493,10 @@ msgstr "ドット映画"
 #: src/pages/editor/Topbar/tabs/AddSentence/AddSentenceTab.tsx:50
 msgid "特殊演出"
 msgstr "特別演出"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:243
+msgid "画布分辨率"
+msgstr "キャンバスの解像度"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:56
 #: src/pages/editor/GraphicalEditor/SentenceEditor/PlayEffect.tsx:50
@@ -1527,7 +1535,7 @@ msgstr "ビュー"
 msgid "视觉小说编辑，再进化"
 msgstr "Galgame Editing. Redefined"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:120
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:176
 msgid "视频"
 msgstr "Video"
 
@@ -1543,12 +1551,12 @@ msgstr "動画のオプション"
 msgid "禁止跳过视频"
 msgstr "動画のスキップを無効にする"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:213
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:223
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:214
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:224
 msgid "禁用"
 msgstr "無効化"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:115
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
 msgid "立绘"
 msgstr "Figure"
 
@@ -1576,23 +1584,19 @@ msgstr "関連する立ち絵のID"
 msgid "立绘文件"
 msgstr "立ち絵ファイル"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:233
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
 msgid "简体中文"
 msgstr "簡体字中国語"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
-msgid "紧急回避"
-msgstr "緊急回避"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "繁体字中国語"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
 msgid "红色（0-255）："
 msgstr "赤(0-255):"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:208
+msgid "紧急回避"
+msgstr "緊急回避"
+
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:175
 msgid "纹理"
 msgstr "Tex"
 
@@ -1622,11 +1626,11 @@ msgstr "絶対"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:140
 #~ msgid "继承上一句"
-#~ msgstr ""
+#~ msgstr "前の文を継承する"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:136
 #~ msgid "继承模式"
-#~ msgstr ""
+#~ msgstr "継承モード"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 msgid "绿色（0-255）："
@@ -1648,6 +1652,10 @@ msgstr "ゲームの編集"
 msgid "编辑组件"
 msgstr "コンポーネントの編集"
 
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+msgid "繁体中文"
+msgstr "繁体字中国語"
+
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
@@ -1660,7 +1668,7 @@ msgid "老电影滤镜"
 msgstr "古い映画"
 
 #: src/components/IconCreator/IconCreator.tsx:696
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:113
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:169
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:64
 msgid "背景"
 msgstr "Background"
@@ -1733,7 +1741,7 @@ msgstr "カスタムの特殊効果名"
 msgid "舞台对象控制"
 msgstr "ステージオブジェクトコントロール"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
 msgid "英语"
 msgstr "英語"
 
@@ -1859,7 +1867,7 @@ msgstr "このファイルタイプはプレビューをサポートしていま
 msgid "语言"
 msgstr "言語"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:121
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:177
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:215
 msgid "语音"
 msgstr "ボイス"
@@ -1888,7 +1896,7 @@ msgstr "シーンを呼び出す"
 msgid "调用场景，新场景结束后返回父场景"
 msgstr "シーンを呼び出し、新しいシーン終了後に親シーンに戻る"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:180
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:242
 msgid "资源"
 msgstr "アセット"
 
@@ -2043,7 +2051,7 @@ msgstr "ゲームディレクトリ名変更"
 msgid "鉴赏"
 msgstr "鑑賞"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:218
 msgid "鉴赏功能"
 msgstr "鑑賞機能"
 
@@ -2096,7 +2104,7 @@ msgstr "右寄せ"
 msgid "靠左"
 msgstr "左寄せ"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:114
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:170
 msgid "音乐"
 msgstr "BGM"
 
@@ -2122,6 +2130,10 @@ msgstr "色調節"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
 msgid "饱和度："
 msgstr "彩度:"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:252
+msgid "高"
+msgstr "高さ"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:48
 msgid "高度"
@@ -2158,7 +2170,7 @@ msgstr "デフォルト値は1"
 msgid "默认值255"
 msgstr "デフォルト値は255"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:228
 msgid "默认语言"
 msgstr "デフォルト言語"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -38,11 +38,11 @@ msgstr ";注释"
 msgid "%"
 msgstr "%"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:189
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:190
 msgid "<0>应用新的模板</0>"
 msgstr "<0>应用新的模板</0>"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:168
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:169
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>当前应用的模板：{currentTemplateName}</0>"
 
@@ -241,7 +241,7 @@ msgstr "不显示角色名"
 #~ msgid "不继承上一句"
 #~ msgstr "不继承上一句"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:232
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:233
 msgid "不设定"
 msgstr "不设定"
 
@@ -363,7 +363,7 @@ msgid "保存"
 msgstr "保存"
 
 #: src/components/IconCreator/IconCreator.tsx:635
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:202
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:203
 msgid "修改游戏图标"
 msgstr "修改游戏图标"
 
@@ -560,7 +560,7 @@ msgid "删除游戏"
 msgstr "删除游戏"
 
 #: src/components/Assets/Assets.tsx:276
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:159
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:221
 msgid "刷新"
 msgstr "刷新"
 
@@ -580,7 +580,7 @@ msgstr "功能区显示"
 msgid "加粗"
 msgstr "加粗"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:111
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:167
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:241
 msgid "动画"
 msgstr "动画"
@@ -639,12 +639,12 @@ msgstr "右对齐"
 msgid "启动、切换或停止背景音乐的播放"
 msgstr "启动、切换或停止背景音乐的播放"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:158
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:159
 msgid "启动图"
 msgstr "启动图"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:212
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:222
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:213
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:223
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:134
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:82
 msgid "启用"
@@ -694,7 +694,7 @@ msgstr "在文件管理器中打开"
 
 #: src/pages/dashboard/GameElement.tsx:97
 #: src/pages/dashboard/TemplateElement.tsx:91
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:165
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:227
 msgid "在新标签页中预览"
 msgstr "在新标签页中预览"
 
@@ -702,8 +702,8 @@ msgstr "在新标签页中预览"
 msgid "在这里放置编辑组件"
 msgstr "在这里放置编辑组件"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:116
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:172
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:243
 msgid "场景"
 msgstr "场景"
 
@@ -765,7 +765,7 @@ msgstr "定位方式"
 msgid "实时预览"
 msgstr "实时预览"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:233
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:92
 msgid "实时预览关闭"
 msgstr "实时预览关闭"
@@ -774,7 +774,7 @@ msgstr "实时预览关闭"
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:233
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:92
 msgid "实时预览打开"
 msgstr "实时预览打开"
@@ -782,6 +782,10 @@ msgstr "实时预览打开"
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:128
 msgid "实验性快速预览"
 msgstr "实验性快速预览"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:246
+msgid "宽"
+msgstr "宽"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:45
 msgid "宽度"
@@ -909,7 +913,7 @@ msgstr "平铺"
 msgid "应用"
 msgstr "应用"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:166
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:167
 msgid "应用的模板"
 msgstr "应用的模板"
 
@@ -930,7 +934,7 @@ msgstr "张开嘴"
 msgid "当前版本"
 msgstr "当前版本"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
 msgid "德语"
 msgstr "德语"
 
@@ -1237,7 +1241,7 @@ msgstr "旋转角度："
 msgid "无"
 msgstr "无"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
 msgid "日语"
 msgstr "日语"
 
@@ -1325,11 +1329,11 @@ msgstr "标题按钮列表"
 msgid "标题按钮文字"
 msgstr "标题按钮文字"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:142
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:143
 msgid "标题背景图片"
 msgstr "标题背景图片"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:150
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:151
 msgid "标题背景音乐"
 msgstr "标题背景音乐"
 
@@ -1339,7 +1343,7 @@ msgid "根文本长度 (rem)"
 msgstr "根文本长度 (rem)"
 
 #: src/pages/dashboard/DashBoard.tsx:214
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:174
 msgid "模板"
 msgstr "模板"
 
@@ -1377,7 +1381,7 @@ msgstr "此指令将结束游戏"
 msgid "永不换行"
 msgstr "永不换行"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
 msgid "法语"
 msgstr "法语"
 
@@ -1455,17 +1459,17 @@ msgstr "游戏"
 msgid "游戏列表"
 msgstr "游戏列表"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:133
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
 msgid "游戏包名"
 msgstr "游戏包名"
 
 #: src/pages/dashboard/Sidebar.tsx:102
 #: src/pages/dashboard/Sidebar.tsx:111
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:121
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:122
 msgid "游戏名称"
 msgstr "游戏名称"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:195
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:196
 msgid "游戏图标"
 msgstr "游戏图标"
 
@@ -1478,15 +1482,15 @@ msgstr "游戏控制"
 msgid "游戏目录"
 msgstr "游戏目录"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:129
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:130
 msgid "游戏简介"
 msgstr "游戏简介"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:125
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:126
 msgid "游戏识别码"
 msgstr "游戏识别码"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:122
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:178
 msgid "游戏配置"
 msgstr "游戏配置"
 
@@ -1509,6 +1513,10 @@ msgstr "点状电影滤镜"
 #: src/pages/editor/Topbar/tabs/AddSentence/AddSentenceTab.tsx:50
 msgid "特殊演出"
 msgstr "特殊演出"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:243
+msgid "画布分辨率"
+msgstr "画布分辨率"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:56
 #: src/pages/editor/GraphicalEditor/SentenceEditor/PlayEffect.tsx:50
@@ -1547,7 +1555,7 @@ msgstr "视图"
 msgid "视觉小说编辑，再进化"
 msgstr "视觉小说编辑，再进化"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:120
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:176
 msgid "视频"
 msgstr "视频"
 
@@ -1563,8 +1571,8 @@ msgstr "视频选项"
 msgid "禁止跳过视频"
 msgstr "禁止跳过视频"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:213
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:223
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:214
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:224
 msgid "禁用"
 msgstr "禁用"
 
@@ -1576,7 +1584,7 @@ msgstr "禁用"
 #~ msgid "移动背景图片"
 #~ msgstr "移动背景图片"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:115
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:171
 msgid "立绘"
 msgstr "立绘"
 
@@ -1604,23 +1612,19 @@ msgstr "立绘插图的ID"
 msgid "立绘文件"
 msgstr "立绘文件"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:233
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
 msgid "简体中文"
 msgstr "简体中文"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
-msgid "紧急回避"
-msgstr "紧急回避"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:234
-msgid "繁体中文"
-msgstr "繁体中文"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:147
 msgid "红色（0-255）："
 msgstr "红色（0-255）："
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:208
+msgid "紧急回避"
+msgstr "紧急回避"
+
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:175
 msgid "纹理"
 msgstr "纹理"
 
@@ -1676,6 +1680,10 @@ msgstr "编辑游戏"
 msgid "编辑组件"
 msgstr "编辑组件"
 
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+msgid "繁体中文"
+msgstr "繁体中文"
+
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
 #: src/components/Transformer/Transformer.tsx:205
@@ -1688,7 +1696,7 @@ msgid "老电影滤镜"
 msgstr "老电影滤镜"
 
 #: src/components/IconCreator/IconCreator.tsx:696
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:113
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:169
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:64
 msgid "背景"
 msgstr "背景"
@@ -1761,7 +1769,7 @@ msgstr "自定义特效名称"
 msgid "舞台对象控制"
 msgstr "舞台对象控制"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
 msgid "英语"
 msgstr "英语"
 
@@ -1887,7 +1895,7 @@ msgstr "该文件类型不支持预览"
 msgid "语言"
 msgstr "语言"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:121
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:177
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:215
 msgid "语音"
 msgstr "语音"
@@ -1916,7 +1924,7 @@ msgstr "调用场景"
 msgid "调用场景，新场景结束后返回父场景"
 msgstr "调用场景，新场景结束后返回父场景"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:180
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:242
 msgid "资源"
 msgstr "资源"
 
@@ -2071,7 +2079,7 @@ msgstr "重命名游戏目录"
 msgid "鉴赏"
 msgstr "鉴赏"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:218
 msgid "鉴赏功能"
 msgstr "鉴赏功能"
 
@@ -2124,7 +2132,7 @@ msgstr "靠右"
 msgid "靠左"
 msgstr "靠左"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:114
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:170
 msgid "音乐"
 msgstr "音乐"
 
@@ -2150,6 +2158,10 @@ msgstr "颜色调整"
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:139
 msgid "饱和度："
 msgstr "饱和度："
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:252
+msgid "高"
+msgstr "高"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:48
 msgid "高度"
@@ -2186,7 +2198,7 @@ msgstr "默认值1"
 msgid "默认值255"
 msgstr "默认值255"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:228
 msgid "默认语言"
 msgstr "默认语言"
 

--- a/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebar.tsx
+++ b/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebar.tsx
@@ -10,9 +10,18 @@ import { t } from "@lingui/macro";
 import { ArrowClockwiseFilled, ArrowClockwiseRegular, LiveFilled, LiveOffFilled, LiveOffRegular, LiveRegular, OpenFilled, OpenRegular, bundleIcon } from "@fluentui/react-icons";
 import { WsUtil } from "@/utils/wsUtil";
 
+enum DraggingDivider {
+  None,
+  EditorSideBarWidth,
+  PreviewWindowHeight,
+}
+
 let startX = 0;
+let startY = 0;
 let prevXvalue = 0;
+let prevYvalue = 0;
 let isMouseDown = false;
+let draggingDivider = DraggingDivider.None;
 
 const ArrowClockwiseIcon = bundleIcon(ArrowClockwiseFilled, ArrowClockwiseRegular);
 const OpenIcon = bundleIcon(OpenFilled, OpenRegular);
@@ -49,6 +58,7 @@ export default function EditorSideBar() {
 
   useEffect(() => {
     const storeWidth = localStorage.getItem('sidebar-width');
+    const storeHeight = localStorage.getItem('sidebar-height');
     if (!storeWidth) {
       const initWidth = window.innerWidth * 0.35;
       localStorage.setItem('sidebar-width', initWidth.toString());
@@ -56,45 +66,91 @@ export default function EditorSideBar() {
     } else {
       document.body.style.setProperty("--sidebar-width", `${storeWidth}px`);
     }
+    if (!storeHeight) {
+      const initHeight = window.innerHeight * 0.35;
+      localStorage.setItem('sidebar-height', initHeight.toString());
+      document.body.style.setProperty("--sidebar-height", `${initHeight}px`);
+    } else {
+      document.body.style.setProperty("--sidebar-height", `${storeHeight}px`);
+    }
   }, []);
 
-  const handleDragStart = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleVerticalDividerDragStart = (event: React.MouseEvent<HTMLDivElement>) => {
     startX = event.clientX;
     const prevX = document.body.style.getPropertyValue("--sidebar-width");
     prevXvalue = parseInt(prevX.substring(0, prevX.length - 2), 10);
     isMouseDown = true;
+    draggingDivider = DraggingDivider.EditorSideBarWidth;
     const previewFrame = document.getElementById("gamePreviewIframe");
     if (previewFrame)
       previewFrame.style.pointerEvents = 'none';
   };
 
-  const handleDrag = (event: MouseEvent) => {
-    if (isMouseDown) {
+  const handleVerticalDividerDrag = (event: MouseEvent) => {
+    if (isMouseDown && draggingDivider === DraggingDivider.EditorSideBarWidth) {
       const deltaX = event.clientX - (startX);
       const newValue = prevXvalue + deltaX;
-      document.body.style.setProperty("--sidebar-width", `${(newValue < 240) ? 240 : newValue}px`);
+      document.body.style.setProperty("--sidebar-width", `${(newValue < 192) ? 192 : newValue}px`);
     }
 
   };
 
-  const handleDragEnd = (event: MouseEvent) => {
+  const handleVerticalDividerDragEnd = (event: MouseEvent) => {
     setTimeout(() => {
       const prevX = document.body.style.getPropertyValue("--sidebar-width");
       prevXvalue = parseInt(prevX.substring(0, prevX.length - 2), 10);
       localStorage.setItem('sidebar-width', prevXvalue.toString());
     }, 10);
     isMouseDown = false;
+    draggingDivider = DraggingDivider.None;
+    const previewFrame = document.getElementById("gamePreviewIframe");
+    if (previewFrame)
+      previewFrame.style.pointerEvents = 'auto';
+  };
+
+  const handleHorizontalDividerDragStart = (event: React.MouseEvent<HTMLDivElement>) => {
+    startY = event.clientY;
+    const prevY = document.body.style.getPropertyValue("--sidebar-height");
+    prevYvalue = parseInt(prevY.substring(0, prevY.length - 2), 10);
+    isMouseDown = true;
+    draggingDivider = DraggingDivider.PreviewWindowHeight;
+    const previewFrame = document.getElementById("gamePreviewIframe");
+    if (previewFrame)
+      previewFrame.style.pointerEvents = 'none';
+  };
+
+  const handleHorizontalDividerDrag = (event: MouseEvent) => {
+    if (isMouseDown && draggingDivider === DraggingDivider.PreviewWindowHeight) {
+      const deltaY = event.clientY - (startY);
+      const newValue = prevYvalue + deltaY;
+      document.body.style.setProperty("--sidebar-height", `${(newValue < 108) ? 108 : newValue}px`);
+    }
+
+  };
+
+  const handleHorizontalDividerDragEnd = (event: MouseEvent) => {
+    setTimeout(() => {
+      const prevY = document.body.style.getPropertyValue("--sidebar-height");
+      prevYvalue = parseInt(prevY.substring(0, prevY.length - 2), 10);
+      localStorage.setItem('sidebar-height', prevYvalue.toString());
+    }, 10);
+    isMouseDown = false;
+    draggingDivider = DraggingDivider.None;
     const previewFrame = document.getElementById("gamePreviewIframe");
     if (previewFrame)
       previewFrame.style.pointerEvents = 'auto';
   };
 
   useEffect(() => {
-    window.addEventListener('mousemove', handleDrag);
-    window.addEventListener('mouseup', handleDragEnd);
+    window.addEventListener('mousemove', handleVerticalDividerDrag);
+    window.addEventListener('mousemove', handleHorizontalDividerDrag);
+    window.addEventListener('mouseup', handleVerticalDividerDragEnd);
+    window.addEventListener('mouseup', handleHorizontalDividerDragEnd);
     return () => {
-      window.removeEventListener('mousemove', handleDrag);
-      window.removeEventListener('mouseup', handleDragEnd);
+      window.removeEventListener('mousemove', handleVerticalDividerDrag);
+      window.removeEventListener('mousemove', handleHorizontalDividerDrag);
+      window.removeEventListener('mouseup', handleVerticalDividerDragEnd);
+      window.removeEventListener('mouseup', handleHorizontalDividerDragEnd);
     };
   }, []);
 
@@ -145,13 +201,19 @@ export default function EditorSideBar() {
       <div className={styles.editor_sidebar}>
         <div className={styles.preview_container} id="gamePreview">
           {/* eslint-disable-next-line react/iframe-missing-sandbox */}
-          <iframe
-            ref={ifRef}
-            id="gamePreviewIframe"
-            frameBorder="0"
-            className={styles.previewWindow}
-            src={`/games/${gameName}`}
-          />
+          <div>
+            <iframe
+              ref={ifRef}
+              id="gamePreviewIframe"
+              frameBorder="0"
+              className={styles.previewWindow}
+              src={`/games/${gameName}`}
+            />
+            <div
+              className={styles.horizontalDivider}
+              onMouseDown={handleHorizontalDividerDragStart}
+            />
+          </div>
           <div className={styles.gamePreviewButons}>
             <Button
               appearance="subtle"
@@ -216,8 +278,8 @@ export default function EditorSideBar() {
         </div>
 
         <div
-          className={styles.divider}
-          onMouseDown={handleDragStart}
+          className={styles.verticalDivider}
+          onMouseDown={handleVerticalDividerDragStart}
         // onMouseUp={handleDragEnd}
         // onMouseLeave={handleDragEnd}
         />

--- a/packages/origine2/src/pages/editor/EditorSidebar/editorSidebar.module.scss
+++ b/packages/origine2/src/pages/editor/EditorSidebar/editorSidebar.module.scss
@@ -32,10 +32,10 @@
   flex: 1;
   flex-shrink: 0;
   width: 100%;
+  height: var(--sidebar-height);
   //margin: 4px 0 4px 0;
   border-radius: var(--radius-md);
   border: var(--border-md);
-  aspect-ratio: 16 / 9;
 }
 
 .preview_container:hover .previewWindow {
@@ -106,7 +106,7 @@
   border-top-left-radius: 0;
 }
 
-.divider {
+.verticalDivider {
   height: calc(100% - 12px);
   width: 2.5px;
   background-color: transparent;
@@ -119,15 +119,40 @@
   background: transparent;
 }
 
-.divider:hover {
+.verticalDivider:hover {
   background: var(--primary);
 }
 
-.divider:active {
+.verticalDivider:active {
   background: var(--primary);
 }
 
-.divider:active+.preview_container {
+.verticalDivider:active+.preview_container {
+  pointer-events: none;
+}
+
+.horizontalDivider {
+  height: 2.5px;
+  width: calc(100% - 12px);
+  background-color: transparent;
+  position: absolute;
+  left: 4px;
+  cursor: ns-resize;
+  bottom: 0.75px;
+  transition: width 0.33s, background-color 0.33s;
+  border-radius: var(--radius-md);
+  background: transparent;
+}
+
+.horizontalDivider:hover {
+  background: var(--primary);
+}
+
+.horizontalDivider:active {
+  background: var(--primary);
+}
+
+.horizontalDivider:active+.preview_container {
   pointer-events: none;
 }
 

--- a/packages/origine2/src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx
+++ b/packages/origine2/src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx
@@ -1,6 +1,6 @@
 import styles from "../topbarTabs.module.scss";
 import {useValue} from "../../../../../hooks/useValue";
-import {useEffect, useRef, useState} from "react";
+import {CSSProperties, useEffect, useRef, useState} from "react";
 import {cloneDeep} from "lodash";
 import ChooseFile from "../../../ChooseFile/ChooseFile";
 import TagTitleWrapper from "@/components/TagTitleWrapper/TagTitleWrapper";
@@ -22,6 +22,7 @@ import {WsUtil} from "@/utils/wsUtil";
 import { TemplateConfigDto, TemplateInfoDto } from "@/api/Api";
 import { IconWithTextItem } from "../../components/IconWithTextItem";
 import IconCreator from "@/components/IconCreator/IconCreator";
+import { TextField } from "@fluentui/react";
 
 const IconsIcon = bundleIcon(IconsFilled, IconsRegular);
 
@@ -239,6 +240,22 @@ export default function GameConfig() {
           ]}
           onChange={(e: string) => updateGameConfigSimpleByKey('Default_Language', e)}/>
       </TabItem>
+      <TabItem title={t`画布分辨率`}>
+        <div style={{flexDirection: "column", display: "flex"}}>
+          <div style={{flexDirection: "row", display: "flex"}}>
+            <div style={{marginLeft: '5px', marginRight: '15px', alignSelf: "center"}}>{t`宽`}</div>
+            <GameConfigEditor key="canvasWidth" value={getConfigContentAsString('Canvas_width')}
+            style={{width: '100px'}}
+            onChange={(e: string) => updateGameConfigSimpleByKey('Canvas_width', e)}/>
+          </div>
+          <div style={{flexDirection: "row", display: "flex"}}>
+            <div style={{marginLeft: '5px', marginRight: '15px', alignSelf: "center"}}>{t`高`}</div>
+            <GameConfigEditor key="canvasHeight" value={getConfigContentAsString('Canvas_height')}
+            style={{width: '100px'}}
+            onChange={(e: string) => updateGameConfigSimpleByKey('Canvas_height', e)}/>
+          </div>
+        </div>
+      </TabItem>
     </>
   );
 }
@@ -246,6 +263,7 @@ export default function GameConfig() {
 interface IGameConfigEditor {
   key: string;
   value: string;
+  style?: CSSProperties;
   onChange: Function;
 }
 
@@ -258,7 +276,8 @@ interface IGameConfigEditorMulti {
 function GameConfigEditor(props: IGameConfigEditor) {
   const showEditBox = useValue(false);
 
-  return <div className={styles.textEditArea} style={{maxWidth: 200}}>
+  return <div className={styles.textEditArea}
+    style={{maxWidth: 200, height: 32, alignItems: 'center', display: "flex"}}>
     {!showEditBox.value && props.value}
     {!showEditBox.value &&
       <span className={styles.editButton} onClick={() => showEditBox.set(true)}>
@@ -268,6 +287,7 @@ function GameConfigEditor(props: IGameConfigEditor) {
       <Input
         autoFocus
         defaultValue={props.value}
+        style={props.style}
         onBlur={(event) => {
           props.onChange(event.target.value);
           showEditBox.set(false);


### PR DESCRIPTION
# 介绍
新增 __画布分辨率__ 配置选项，预览窗口可垂直调整大小，

- [x] 英文翻译
- [x] 日文翻译

此 PR 以 OpenWebGAL/WebGAL#687 为前提

![image](https://github.com/user-attachments/assets/0f131e84-43e4-42a5-b48e-fcb2510920d1)
![image](https://github.com/user-attachments/assets/d8d99f8b-cc9d-421e-a2ec-82e9192bd659)

## 注意
- 修改画布分辨率后，需要刷新游戏以生效
- 预览窗口宽高比小于 1:1 时，画面会发生旋转，需自行调整预览窗口比例