### PR TITLE
feat: add ease write default and keep option

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -30,7 +30,7 @@ msgstr "<0>Apply a new template</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>Current template: {currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:193
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:214
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,11 @@ msgstr "Intro texts"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:199
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "Live2D 动作"
 msgstr "Live2D Motion"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:209
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:231
 msgid "Live2D 表情"
 msgstr "Live2D Expression"
 
@@ -142,9 +142,9 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:204
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "Spine 动画"
-msgstr ""
+msgstr "Spine animation"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:197
 msgid "unlockBgm:;"
@@ -192,7 +192,7 @@ msgstr "Y"
 msgid "Y轴缩放"
 msgstr "Scale y"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:185
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
 msgid "z-index"
 msgstr "z-index"
 
@@ -246,13 +246,13 @@ msgstr " Words"
 msgid "中"
 msgstr "Medium"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:51
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:54
 msgid "中间"
 msgstr "Center"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:31
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:21
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:29
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:30
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:22
 msgid "中间立绘"
 msgstr "Figure at center"
@@ -324,19 +324,19 @@ msgstr "Use the special effects defined by user"
 msgid "使用预制特效"
 msgstr "Use prepared special effects"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:57
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:61
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:91
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:63
 msgid "使用预设的作用目标，如果设置了id则不生效"
 msgstr "Use prepared apply target, if target set the ID, it won't apply"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:54
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:80
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:58
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:88
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:60
 msgid "使用预设目标"
 msgstr "Use prepared target"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:227
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:250
 msgid "例如：-100,-100,100,100"
 msgstr "For example: -100,-100,100,100 "
 
@@ -425,6 +425,8 @@ msgstr "About"
 msgid "关联立绘"
 msgstr "Associated figure"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:136
 #: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:49
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:133
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:81
@@ -441,13 +443,13 @@ msgstr "Hide the avatar"
 msgid "关闭效果音"
 msgstr "Stop the sound effect"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:158
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:165
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:179
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
 msgid "关闭立绘"
 msgstr "Hide the figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:50
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:63
 msgid "关闭背景"
 msgstr "Hide the background"
 
@@ -589,7 +591,7 @@ msgstr "Bold"
 msgid "动画"
 msgstr "Animation"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:299
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:332
 msgid "半张嘴"
 msgstr "Half open mouth"
 
@@ -633,13 +635,13 @@ msgstr "Transform"
 msgid "可选项"
 msgstr "Selectable options"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:53
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
 msgid "右侧"
 msgstr "Right"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:32
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:22
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:30
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:31
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:23
 msgid "右侧立绘"
 msgstr "Right side figure"
@@ -667,7 +669,7 @@ msgstr "Enabled"
 msgid "启用视频跳过"
 msgstr "Enable video skipping"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:276
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:309
 msgid "唇形同步与眨眼"
 msgstr "Lip sync and blinking"
 
@@ -688,21 +690,15 @@ msgstr "Image"
 msgid "圆形"
 msgstr "Circle"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:32
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:67
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:41
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
 msgid "圆形缓入"
 msgstr "Circ in"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:34
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:69
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:43
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
 msgid "圆形缓入缓出"
 msgstr "Circ in out"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:33
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:68
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:42
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
 msgid "圆形缓出"
 msgstr "Circ out"
 
@@ -909,13 +905,13 @@ msgstr "Show avatar"
 msgid "属性"
 msgstr "Property"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:52
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:55
 msgid "左侧"
 msgstr "Left"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:30
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:20
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:28
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:29
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:21
 msgid "左侧立绘"
 msgstr "Left side figure"
@@ -971,7 +967,12 @@ msgstr "Apply color changes"
 msgid "延迟时间（秒）"
 msgstr "Delay time (seconds)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:287
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:136
+msgid "开启"
+msgstr "On"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:320
 msgid "张开嘴"
 msgstr "Open mouth"
 
@@ -1000,15 +1001,15 @@ msgstr "I'm sure to delete the game"
 msgid "手动触发下一句"
 msgstr "Manually trigger next intro sentence"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:57
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:61
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:91
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:63
 msgid "手动输入 ID"
 msgstr "Manually enter ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:91
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:53
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:107
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:292
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:61
 msgid "打开效果编辑器"
 msgstr "Open effect editor"
 
@@ -1028,12 +1029,12 @@ msgstr "Concat the sentences with previous text"
 msgid "拼接模式"
 msgstr "Concat mode"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:97
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:100
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:265
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:267
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:65
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:113
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:116
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:298
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:300
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:70
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:73
 msgid "持续时间（单位为毫秒）"
 msgstr "Duration (unit milliseconds)"
 
@@ -1066,7 +1067,11 @@ msgstr "Submit"
 msgid "提交修改"
 msgstr "Submit changes"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:42
+#: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:49
+msgid "提示"
+msgstr "Tip"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:46
 msgid "提示：先设置立绘/背景，再应用动画，否则找不到目标。"
 msgstr "Tip: Set the figure/background first, then apply the animation, otherwise the target cannot be found."
 
@@ -1078,11 +1083,11 @@ msgstr "Tip: After editing, if you find any invalid CG/BGM in the appreciation g
 msgid "提示：换行符最多可达三行"
 msgstr "Tip: Line breaks can be up to three lines"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:382
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "Tip: The effect will only take place when switching to a different character sprite or closing the current sprite and adding it again. If you want to set an effect for an existing sprite, please use a separate command for setting effects."
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:133
 msgid "提示：效果只有在切换到不同背景或关闭之前的背景再重新添加时生效。如果你要为现有的背景设置效果，请使用单独的设置效果命令"
 msgstr "Tip: The effect will only take place when switching to a different background or removing the current background and adding it again. If you want to set an effect for an existing background, please use a separate command for setting effects."
 
@@ -1122,13 +1127,13 @@ msgstr "Effects and Transformations"
 msgid "效果声音"
 msgstr "Sound effect"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:51
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:59
 msgid "效果编辑"
 msgstr "Effect editing"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:95
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:262
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:55
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:111
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:295
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:63
 msgid "效果编辑器"
 msgstr "Effect editor"
 
@@ -1316,8 +1321,8 @@ msgstr "Are you sure you want to delete \"{gameName}\"?"
 msgid "显示侧边栏"
 msgstr "Show sidebar"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:88
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:256
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:104
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:289
 msgid "显示效果"
 msgstr "Display effect"
 
@@ -1325,11 +1330,11 @@ msgstr "Display effect"
 msgid "显示文本框"
 msgstr "Show text box"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:165
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
 msgid "显示立绘"
 msgstr "Show figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:63
 msgid "显示背景"
 msgstr "Show background"
 
@@ -1357,17 +1362,17 @@ msgstr "Unrecognized command"
 msgid "本句前插入句子"
 msgstr "Insert sentence before this"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:73
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:182
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:79
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:203
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:142
 msgid "本句执行后执行下一句"
 msgstr "Execute next sentence after this"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:74
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:183
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:204
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:142
 msgid "本句执行后等待"
 msgstr "Wait after this sentence"
 
@@ -1603,7 +1608,7 @@ msgstr "No file currently open"
 msgid "相对"
 msgstr "Relative"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:323
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:356
 msgid "睁开眼睛"
 msgstr "Open eyes"
 
@@ -1652,19 +1657,19 @@ msgstr "Disabled"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:275
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:78
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:104
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:84
 msgid "立绘 ID"
 msgstr "Figure ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:244
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:267
 msgid "立绘ID（可选）"
 msgstr "Figure ID (optional)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:234
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:257
 msgid "立绘位置"
 msgstr "Figure position"
 
@@ -1672,7 +1677,7 @@ msgstr "Figure position"
 msgid "立绘插图的ID"
 msgstr "ID of figure illustration"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:168
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:189
 msgid "立绘文件"
 msgstr "Figure file"
 
@@ -1688,15 +1693,21 @@ msgstr "Emergency Evasion"
 msgid "纹理"
 msgstr "Texture"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:28
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:37
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
 msgid "线性"
 msgstr "Linear"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGBackgroundEditor.tsx:52
 msgid "线性渐变"
 msgstr "Linear gradient"
+
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
+msgid "终点回弹"
+msgstr "Back out"
+
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
+msgid "终点弹跳"
+msgstr "Bounce out"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:274
 msgid "结束后保持"
@@ -1727,13 +1738,13 @@ msgstr "Absolutely"
 #~ msgid "继承模式"
 #~ msgstr "Inheritance mode"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:90
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:130
 msgid "继承现有效果"
 msgstr "Inherit current effect"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:90
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:130
 msgid "继承默认效果"
 msgstr "Inherit default effect"
 
@@ -1741,27 +1752,21 @@ msgstr "Inherit default effect"
 #~ msgid "绿色（0-255）："
 #~ msgstr "Green (0-255)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:29
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:64
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:38
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
 msgid "缓入"
 msgstr "Ease in"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:31
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:66
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:40
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
 msgid "缓入缓出"
 msgstr "Ease in out"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:30
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:65
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:39
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
 msgid "缓出"
 msgstr "Ease out"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:263
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:123
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:82
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:116
 msgid "缓动类型"
 msgstr "Ease type"
 
@@ -1818,12 +1823,12 @@ msgid "背景图像大小"
 msgstr "Background image size"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:23
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:31
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:32
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:24
 msgid "背景图片"
 msgstr "Background image"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:59
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:65
 msgid "背景文件"
 msgstr "Background file"
 
@@ -1860,7 +1865,7 @@ msgstr "Auto-hide toolbar"
 msgid "自定义"
 msgstr "Customization"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:219
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "自定义 Live2D 绘制范围"
 msgstr "Custom Live2D drawing area"
 
@@ -1898,8 +1903,8 @@ msgstr "Get input"
 msgid "行脚本"
 msgstr "Line of script"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:77
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:133
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:126
 msgid "补充默认值"
 msgstr "Write default"
 
@@ -1948,7 +1953,7 @@ msgid "角落头像"
 msgstr "Corner avatar"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:85
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:92
 #: src/pages/editor/GraphicalEditor/SentenceEditor/UnlockExtra.tsx:73
 msgid "解锁名称"
 msgstr "Unlock name"
@@ -1957,7 +1962,7 @@ msgstr "Unlock name"
 msgid "解锁的 BGM 名称"
 msgstr "Name of unlocked BGM"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:101
 msgid "解锁的 CG 名称"
 msgstr "Name of unlocked CG"
 
@@ -2045,32 +2050,24 @@ msgstr "Call scene, return to parent scene after new scene ends"
 msgid "资源"
 msgstr "Assets"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:37
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
 msgid "起止回弹"
 msgstr "Back in out"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:40
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:75
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:49
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
 msgid "起止弹跳"
 msgstr "Bounce in out"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:35
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:70
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
 msgid "起点回弹"
 msgstr "Back in"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:38
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:47
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
 msgid "起点弹跳"
 msgstr "Bounce in"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:92
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:132
 msgid "跨语句动画"
 msgstr "Keep animation"
 
@@ -2078,8 +2075,8 @@ msgstr "Keep animation"
 msgid "软化（0-1）"
 msgstr "Softness (0-1)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:70
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:74
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:104
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:76
 msgid "输入目标 ID"
 msgstr "Enter Target ID"
@@ -2100,10 +2097,10 @@ msgstr "Return"
 msgid "进出场动画"
 msgstr "Entry and exit animation"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:69
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:178
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:108
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:75
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:199
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:138
 msgid "连续执行"
 msgstr "Execute Continuously"
 
@@ -2111,11 +2108,11 @@ msgstr "Execute Continuously"
 msgid "选择"
 msgstr "Choose"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:45
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:49
 msgid "选择动画"
 msgstr "Choose animation"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:48
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:52
 msgid "选择动画文件"
 msgstr "Choose animation file"
 
@@ -2163,18 +2160,18 @@ msgstr "Select game engine version"
 msgid "选择视频文件"
 msgstr "Choose video file"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:161
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:171
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:290
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:302
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:314
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:182
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:192
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:323
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:335
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:347
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:359
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:371
 msgid "选择立绘文件"
 msgstr "Choose Figure File"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:53
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:62
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:59
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:68
 msgid "选择背景文件"
 msgstr "Choose background file"
 
@@ -2207,8 +2204,8 @@ msgstr "Choose exit animation file"
 msgid "选择鉴赏资源文件"
 msgstr "Choose appreciation asset file"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:60
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:86
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:64
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:94
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:66
 msgid "选择预设目标"
 msgstr "Choose Preset Target"
@@ -2297,11 +2294,11 @@ msgstr "Appreciation Asset File"
 msgid "鉴赏音乐"
 msgstr "Appreciation Music"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:311
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:344
 msgid "闭上嘴"
 msgstr "Close Mouth"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:335
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:368
 msgid "闭上眼睛"
 msgstr "Close Eyes"
 
@@ -2354,9 +2351,7 @@ msgstr "Music"
 msgid "项目主页"
 msgstr "Project Homepage"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:41
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:50
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
 msgid "预先反向"
 msgstr "Anticipate"
 
@@ -2388,6 +2383,7 @@ msgid "高斯模糊"
 msgstr "Gaussian Blur"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:4
 msgid "默认"
 msgstr "Default"
 

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -688,6 +688,24 @@ msgstr "Image"
 msgid "圆形"
 msgstr "Circle"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:32
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:67
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:41
+msgid "圆形缓入"
+msgstr "Circ in"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:34
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:69
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:43
+msgid "圆形缓入缓出"
+msgstr "Circ in out"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:33
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:68
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:42
+msgid "圆形缓出"
+msgstr "Circ out"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:59
 msgid "圆角"
 msgstr "Rounded corners"
@@ -1670,6 +1688,12 @@ msgstr "Emergency Evasion"
 msgid "纹理"
 msgstr "Texture"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:28
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:37
+msgid "线性"
+msgstr "Linear"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGBackgroundEditor.tsx:52
 msgid "线性渐变"
 msgstr "Linear gradient"
@@ -1703,9 +1727,43 @@ msgstr "Absolutely"
 #~ msgid "继承模式"
 #~ msgstr "Inheritance mode"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+msgid "继承现有效果"
+msgstr "Inherit current effect"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+msgid "继承默认效果"
+msgstr "Inherit default effect"
+
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 #~ msgid "绿色（0-255）："
 #~ msgstr "Green (0-255)"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:29
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:64
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:38
+msgid "缓入"
+msgstr "Ease in"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:31
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:66
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:40
+msgid "缓入缓出"
+msgstr "Ease in out"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:30
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:65
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:39
+msgid "缓出"
+msgstr "Ease out"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:263
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:123
+msgid "缓动类型"
+msgstr "Ease type"
 
 #: src/components/IconCreator/IconCreator.tsx:625
 msgid "编辑图标"
@@ -1839,6 +1897,11 @@ msgstr "Get input"
 #: src/pages/editor/MainArea/EditorToolbar.tsx:56
 msgid "行脚本"
 msgstr "Line of script"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:77
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:133
+msgid "补充默认值"
+msgstr "Write default"
 
 #: src/components/IconCreator/IconCreator.tsx:724
 msgid "裁剪形状"
@@ -1981,6 +2044,35 @@ msgstr "Call scene, return to parent scene after new scene ends"
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:147
 msgid "资源"
 msgstr "Assets"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:37
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
+msgid "起止回弹"
+msgstr "Back in out"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:40
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:75
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:49
+msgid "起止弹跳"
+msgstr "Bounce in out"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:35
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:70
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
+msgid "起点回弹"
+msgstr "Back in"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:38
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:47
+msgid "起点弹跳"
+msgstr "Bounce in"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
+msgid "跨语句动画"
+msgstr "Keep animation"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:385
 msgid "软化（0-1）"
@@ -2261,6 +2353,12 @@ msgstr "Music"
 #: src/pages/dashboard/About.tsx:63
 msgid "项目主页"
 msgstr "Project Homepage"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:41
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:76
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:50
+msgid "预先反向"
+msgstr "Anticipate"
 
 #: src/components/IconCreator/IconCreator.tsx:625
 msgid "预览图标"

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -691,6 +691,24 @@ msgstr "画像"
 msgid "圆形"
 msgstr "円形"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:32
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:67
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:41
+msgid "圆形缓入"
+msgstr "サークイン"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:34
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:69
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:43
+msgid "圆形缓入缓出"
+msgstr "サークインアウト"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:33
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:68
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:42
+msgid "圆形缓出"
+msgstr "サークアウト"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:59
 msgid "圆角"
 msgstr "角丸"
@@ -1669,6 +1687,12 @@ msgstr "緊急回避"
 msgid "纹理"
 msgstr "Tex"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:28
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:37
+msgid "线性"
+msgstr "リニア"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGBackgroundEditor.tsx:52
 msgid "线性渐变"
 msgstr "線形グラデーション"
@@ -1702,9 +1726,43 @@ msgstr "絶対"
 #~ msgid "继承模式"
 #~ msgstr "継承モード"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+msgid "继承现有效果"
+msgstr "現在の効果を継承する"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+msgid "继承默认效果"
+msgstr "デフォルトの効果を継承する"
+
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 #~ msgid "绿色（0-255）："
 #~ msgstr "緑(0-255):"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:29
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:64
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:38
+msgid "缓入"
+msgstr "イーズイン"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:31
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:66
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:40
+msgid "缓入缓出"
+msgstr "イーズインアウト"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:30
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:65
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:39
+msgid "缓出"
+msgstr "イーズアウト"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:263
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:123
+msgid "缓动类型"
+msgstr "イージングタイプ"
 
 #: src/components/IconCreator/IconCreator.tsx:625
 msgid "编辑图标"
@@ -1838,6 +1896,11 @@ msgstr "入力を取得"
 #: src/pages/editor/MainArea/EditorToolbar.tsx:56
 msgid "行脚本"
 msgstr " スクリプトの行、"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:77
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:133
+msgid "补充默认值"
+msgstr "デフォルト値を補う"
 
 #: src/components/IconCreator/IconCreator.tsx:724
 msgid "裁剪形状"
@@ -1980,6 +2043,35 @@ msgstr "シーンを呼び出し、新しいシーン終了後に親シーンに
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:147
 msgid "资源"
 msgstr "アセット"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:37
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
+msgid "起止回弹"
+msgstr "バックインアウト"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:40
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:75
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:49
+msgid "起止弹跳"
+msgstr "バウンスインアウト"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:35
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:70
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
+msgid "起点回弹"
+msgstr "バックイン"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:38
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:47
+msgid "起点弹跳"
+msgstr "バウンスイン"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
+msgid "跨语句动画"
+msgstr "アニメーションを維持する"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:385
 msgid "软化（0-1）"
@@ -2260,6 +2352,12 @@ msgstr "BGM"
 #: src/pages/dashboard/About.tsx:63
 msgid "项目主页"
 msgstr "プロジェクトホームページ"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:41
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:76
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:50
+msgid "预先反向"
+msgstr "アンティシペート"
 
 #: src/components/IconCreator/IconCreator.tsx:625
 msgid "预览图标"

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -30,7 +30,7 @@ msgstr "<0>新しいテンプレートを適用する</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>現在適用中のテンプレート：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:193
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:214
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,11 @@ msgstr "Intro テキスト"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:199
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "Live2D 动作"
 msgstr "Live2D モーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:209
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:231
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -142,9 +142,9 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:204
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "Spine 动画"
-msgstr ""
+msgstr "Spine アニメーション"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:197
 msgid "unlockBgm:;"
@@ -195,7 +195,7 @@ msgstr "Y軸位移"
 msgid "Y轴缩放"
 msgstr "Y軸スケール"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:185
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
 msgid "z-index"
 msgstr "z-index"
 
@@ -249,13 +249,13 @@ msgstr " ワード"
 msgid "中"
 msgstr "中央"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:51
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:54
 msgid "中间"
 msgstr "中央"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:31
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:21
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:29
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:30
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:22
 msgid "中间立绘"
 msgstr "中央の立ち絵"
@@ -327,19 +327,19 @@ msgstr "カスタムの特殊効果を使用"
 msgid "使用预制特效"
 msgstr "プレハブ効果を使用"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:57
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:61
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:91
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:63
 msgid "使用预设的作用目标，如果设置了id则不生效"
 msgstr "以前に設定されたアクションターゲットを使用。IDを設定した場合は無効"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:54
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:80
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:58
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:88
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:60
 msgid "使用预设目标"
 msgstr "事前設定されたターゲットを使用"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:227
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:250
 msgid "例如：-100,-100,100,100"
 msgstr "例えば：-100,-100,100,100"
 
@@ -428,6 +428,8 @@ msgstr "About"
 msgid "关联立绘"
 msgstr "関連する立ち絵"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:136
 #: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:49
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:133
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:81
@@ -444,13 +446,13 @@ msgstr "アバターを非表示"
 msgid "关闭效果音"
 msgstr "効果音を停止"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:158
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:165
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:179
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
 msgid "关闭立绘"
 msgstr "立ち絵を非表示"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:50
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:63
 msgid "关闭背景"
 msgstr "背景画像を非表示"
 
@@ -592,7 +594,7 @@ msgstr "太字"
 msgid "动画"
 msgstr "アニメーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:299
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:332
 msgid "半张嘴"
 msgstr "半分開いた口"
 
@@ -636,13 +638,13 @@ msgstr "トランスフォーム"
 msgid "可选项"
 msgstr "選択可能な選択肢"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:53
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
 msgid "右侧"
 msgstr "右"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:32
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:22
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:30
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:31
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:23
 msgid "右侧立绘"
 msgstr "右の立ち絵"
@@ -670,7 +672,7 @@ msgstr "有効化"
 msgid "启用视频跳过"
 msgstr "動画のスキップを有効にする"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:276
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:309
 msgid "唇形同步与眨眼"
 msgstr "口パクとまばたき"
 
@@ -691,21 +693,15 @@ msgstr "画像"
 msgid "圆形"
 msgstr "円形"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:32
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:67
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:41
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
 msgid "圆形缓入"
 msgstr "サークイン"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:34
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:69
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:43
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
 msgid "圆形缓入缓出"
 msgstr "サークインアウト"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:33
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:68
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:42
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
 msgid "圆形缓出"
 msgstr "サークアウト"
 
@@ -912,13 +908,13 @@ msgstr "アバターを表示"
 msgid "属性"
 msgstr "プロパティ"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:52
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:55
 msgid "左侧"
 msgstr "左"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:30
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:20
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:28
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:29
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:21
 msgid "左侧立绘"
 msgstr "左の立ち絵"
@@ -974,7 +970,12 @@ msgstr "色の変更を適用"
 msgid "延迟时间（秒）"
 msgstr "遅延時間（秒）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:287
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:136
+msgid "开启"
+msgstr "有効化"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:320
 msgid "张开嘴"
 msgstr "開いた口"
 
@@ -1003,15 +1004,15 @@ msgstr "ゲームを削除することを確認しました"
 msgid "手动触发下一句"
 msgstr "手動で次の行を表示"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:57
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:61
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:91
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:63
 msgid "手动输入 ID"
 msgstr "IDを手動で設定"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:91
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:53
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:107
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:292
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:61
 msgid "打开效果编辑器"
 msgstr "エフェクトエディタを開く"
 
@@ -1031,12 +1032,12 @@ msgstr "前のテキストボックスの内容をつなげる"
 msgid "拼接模式"
 msgstr "連結モード"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:97
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:100
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:265
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:267
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:65
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:113
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:116
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:298
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:300
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:70
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:73
 msgid "持续时间（单位为毫秒）"
 msgstr "持続時間（ミリ秒）"
 
@@ -1069,7 +1070,11 @@ msgstr "提出"
 msgid "提交修改"
 msgstr "変更を送信"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:42
+#: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:49
+msgid "提示"
+msgstr "ヒント"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:46
 msgid "提示：先设置立绘/背景，再应用动画，否则找不到目标。"
 msgstr "ヒント: 最初に立ち絵の描画/背景を設定してから、アニメーションを適用します。そうしないと、ターゲットが見つかりません。"
 
@@ -1081,11 +1086,11 @@ msgstr "ヒント: 編集後に無効なCG/BGMが見つかった場合は、WebG
 msgid "提示：换行符最多可达三行"
 msgstr "ヒント:改行は三行まで可能"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:382
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "ヒント：この効果は、異なる立ち絵に切り替えるか、一度立ち絵を閉じてから再度追加した場合にのみ有効です。既存の立ち絵に効果を設定する場合は、個別の効果設定コマンドを使用してください。"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:133
 msgid "提示：效果只有在切换到不同背景或关闭之前的背景再重新添加时生效。如果你要为现有的背景设置效果，请使用单独的设置效果命令"
 msgstr "ヒント：エフェクトは、異なる背景に切り替えるか、一度背景を削除してから再度追加した場合にのみ有効になります。既存の背景にエフェクトを設定する場合は、専用の「エフェクト設定」コマンドを使用してください。"
 
@@ -1125,13 +1130,13 @@ msgstr "効果と変身"
 msgid "效果声音"
 msgstr "効果音"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:51
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:59
 msgid "效果编辑"
 msgstr "エフェクトエディタ"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:95
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:262
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:55
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:111
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:295
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:63
 msgid "效果编辑器"
 msgstr "エフェクトエディタ"
 
@@ -1315,8 +1320,8 @@ msgstr "\"{gameName}\"を削除してもよろしいですか？"
 msgid "显示侧边栏"
 msgstr "サイドバーを表示"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:88
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:256
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:104
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:289
 msgid "显示效果"
 msgstr "エフェクト"
 
@@ -1324,11 +1329,11 @@ msgstr "エフェクト"
 msgid "显示文本框"
 msgstr "テキストボックスを表示"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:165
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
 msgid "显示立绘"
 msgstr "立ち絵を表示"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:63
 msgid "显示背景"
 msgstr "背景画像を表示"
 
@@ -1356,17 +1361,17 @@ msgstr "認識されないコマンド"
 msgid "本句前插入句子"
 msgstr "選択した文の前に追加"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:73
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:182
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:79
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:203
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:142
 msgid "本句执行后执行下一句"
 msgstr "この文が実行された後、次の文を実行"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:74
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:183
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:204
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:142
 msgid "本句执行后等待"
 msgstr "この文が実行されるのを待つ"
 
@@ -1602,7 +1607,7 @@ msgstr "現在開いているファイルはありません"
 msgid "相对"
 msgstr "相対"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:323
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:356
 msgid "睁开眼睛"
 msgstr "開いた目"
 
@@ -1651,19 +1656,19 @@ msgstr "無効化"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:275
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:78
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:104
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:84
 msgid "立绘 ID"
 msgstr "立ち絵ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:244
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:267
 msgid "立绘ID（可选）"
 msgstr "立ち絵ID(オプション)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:234
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:257
 msgid "立绘位置"
 msgstr "描画位置"
 
@@ -1671,7 +1676,7 @@ msgstr "描画位置"
 msgid "立绘插图的ID"
 msgstr "関連する立ち絵のID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:168
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:189
 msgid "立绘文件"
 msgstr "立ち絵ファイル"
 
@@ -1687,15 +1692,21 @@ msgstr "緊急回避"
 msgid "纹理"
 msgstr "Tex"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:28
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:37
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
 msgid "线性"
 msgstr "リニア"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGBackgroundEditor.tsx:52
 msgid "线性渐变"
 msgstr "線形グラデーション"
+
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
+msgid "终点回弹"
+msgstr "バックアウト"
+
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
+msgid "终点弹跳"
+msgstr "バウンスアウト"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:274
 msgid "结束后保持"
@@ -1726,13 +1737,13 @@ msgstr "絶対"
 #~ msgid "继承模式"
 #~ msgstr "継承モード"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:90
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:130
 msgid "继承现有效果"
 msgstr "現在の効果を継承する"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:90
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:130
 msgid "继承默认效果"
 msgstr "デフォルトの効果を継承する"
 
@@ -1740,27 +1751,21 @@ msgstr "デフォルトの効果を継承する"
 #~ msgid "绿色（0-255）："
 #~ msgstr "緑(0-255):"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:29
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:64
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:38
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
 msgid "缓入"
 msgstr "イーズイン"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:31
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:66
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:40
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
 msgid "缓入缓出"
 msgstr "イーズインアウト"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:30
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:65
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:39
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
 msgid "缓出"
 msgstr "イーズアウト"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:263
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:123
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:82
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:116
 msgid "缓动类型"
 msgstr "イージングタイプ"
 
@@ -1817,12 +1822,12 @@ msgid "背景图像大小"
 msgstr "背景画像サイズ"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:23
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:31
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:32
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:24
 msgid "背景图片"
 msgstr "背景画像"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:59
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:65
 msgid "背景文件"
 msgstr "背景画像ファイル"
 
@@ -1859,7 +1864,7 @@ msgstr "ツールバーを自動的に隠す"
 msgid "自定义"
 msgstr "カスタム"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:219
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "自定义 Live2D 绘制范围"
 msgstr "Live2D 描画範囲のカスタマイズ"
 
@@ -1897,8 +1902,8 @@ msgstr "入力を取得"
 msgid "行脚本"
 msgstr " スクリプトの行、"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:77
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:133
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:126
 msgid "补充默认值"
 msgstr "デフォルト値を補う"
 
@@ -1947,7 +1952,7 @@ msgid "角落头像"
 msgstr "コーナーアバター"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:85
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:92
 #: src/pages/editor/GraphicalEditor/SentenceEditor/UnlockExtra.tsx:73
 msgid "解锁名称"
 msgstr "CG/BGMの名前"
@@ -1956,7 +1961,7 @@ msgstr "CG/BGMの名前"
 msgid "解锁的 BGM 名称"
 msgstr "BGMの名前"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:101
 msgid "解锁的 CG 名称"
 msgstr "CGの名前"
 
@@ -2044,32 +2049,24 @@ msgstr "シーンを呼び出し、新しいシーン終了後に親シーンに
 msgid "资源"
 msgstr "アセット"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:37
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
 msgid "起止回弹"
 msgstr "バックインアウト"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:40
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:75
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:49
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
 msgid "起止弹跳"
 msgstr "バウンスインアウト"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:35
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:70
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
 msgid "起点回弹"
 msgstr "バックイン"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:38
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:47
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
 msgid "起点弹跳"
 msgstr "バウンスイン"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:92
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:132
 msgid "跨语句动画"
 msgstr "アニメーションを維持する"
 
@@ -2077,8 +2074,8 @@ msgstr "アニメーションを維持する"
 msgid "软化（0-1）"
 msgstr "柔らかさ (0-1)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:70
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:74
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:104
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:76
 msgid "输入目标 ID"
 msgstr "ターゲットIDを入力"
@@ -2099,10 +2096,10 @@ msgstr "戻る"
 msgid "进出场动画"
 msgstr "入退場アニメーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:69
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:178
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:108
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:75
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:199
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:138
 msgid "连续执行"
 msgstr "連続実行"
 
@@ -2110,11 +2107,11 @@ msgstr "連続実行"
 msgid "选择"
 msgstr "選択"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:45
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:49
 msgid "选择动画"
 msgstr "アニメーションを選択"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:48
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:52
 msgid "选择动画文件"
 msgstr "アニメーションファイルを選択"
 
@@ -2162,18 +2159,18 @@ msgstr "ゲームエンジンのバージョンを選択"
 msgid "选择视频文件"
 msgstr "動画ファイルを選択"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:161
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:171
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:290
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:302
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:314
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:182
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:192
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:323
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:335
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:347
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:359
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:371
 msgid "选择立绘文件"
 msgstr "立ち絵ファイルを選択"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:53
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:62
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:59
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:68
 msgid "选择背景文件"
 msgstr "背景画像ファイルを選択"
 
@@ -2206,8 +2203,8 @@ msgstr "出るアニメーションファイルを選択"
 msgid "选择鉴赏资源文件"
 msgstr "CG/BGMファイルを選択"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:60
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:86
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:64
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:94
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:66
 msgid "选择预设目标"
 msgstr "事前設定されたターゲットを選択"
@@ -2296,11 +2293,11 @@ msgstr "CG/BGMファイルを選択"
 msgid "鉴赏音乐"
 msgstr "BGM鑑賞"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:311
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:344
 msgid "闭上嘴"
 msgstr "閉じた口"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:335
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:368
 msgid "闭上眼睛"
 msgstr "閉じた目"
 
@@ -2353,9 +2350,7 @@ msgstr "BGM"
 msgid "项目主页"
 msgstr "プロジェクトホームページ"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:41
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:50
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
 msgid "预先反向"
 msgstr "アンティシペート"
 
@@ -2387,6 +2382,7 @@ msgid "高斯模糊"
 msgstr "ぼかし"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:4
 msgid "默认"
 msgstr "デフォルト"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -30,7 +30,7 @@ msgstr "<0>应用新的模板</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>当前应用的模板：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:193
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:214
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,11 @@ msgstr "Intro 文本"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:199
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "Live2D 动作"
 msgstr "Live2D 动作"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:209
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:231
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -142,7 +142,7 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:204
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "Spine 动画"
 msgstr "Spine 动画"
 
@@ -194,7 +194,7 @@ msgstr "Y轴位移"
 msgid "Y轴缩放"
 msgstr "Y轴缩放"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:185
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
 msgid "z-index"
 msgstr "z-index"
 
@@ -248,13 +248,13 @@ msgstr "个字"
 msgid "中"
 msgstr "中"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:51
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:54
 msgid "中间"
 msgstr "中间"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:31
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:21
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:29
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:30
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:22
 msgid "中间立绘"
 msgstr "中间立绘"
@@ -326,19 +326,19 @@ msgstr "使用自定义特效"
 msgid "使用预制特效"
 msgstr "使用预制特效"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:57
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:61
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:91
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:63
 msgid "使用预设的作用目标，如果设置了id则不生效"
 msgstr "使用预设的作用目标，如果设置了id则不生效"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:54
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:80
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:58
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:88
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:60
 msgid "使用预设目标"
 msgstr "使用预设目标"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:227
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:250
 msgid "例如：-100,-100,100,100"
 msgstr "例如：-100,-100,100,100"
 
@@ -427,6 +427,8 @@ msgstr "关于"
 msgid "关联立绘"
 msgstr "关联立绘"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:136
 #: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:49
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:133
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:81
@@ -443,13 +445,13 @@ msgstr "关闭小头像"
 msgid "关闭效果音"
 msgstr "关闭效果音"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:158
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:165
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:179
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
 msgid "关闭立绘"
 msgstr "关闭立绘"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:50
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:63
 msgid "关闭背景"
 msgstr "关闭背景"
 
@@ -591,7 +593,7 @@ msgstr "加粗"
 msgid "动画"
 msgstr "动画"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:299
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:332
 msgid "半张嘴"
 msgstr "半张嘴"
 
@@ -635,13 +637,13 @@ msgstr "变换"
 msgid "可选项"
 msgstr "可选项"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:53
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
 msgid "右侧"
 msgstr "右侧"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:32
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:22
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:30
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:31
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:23
 msgid "右侧立绘"
 msgstr "右侧立绘"
@@ -669,7 +671,7 @@ msgstr "启用"
 msgid "启用视频跳过"
 msgstr "启用视频跳过"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:276
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:309
 msgid "唇形同步与眨眼"
 msgstr "唇形同步与眨眼"
 
@@ -690,21 +692,15 @@ msgstr "图片"
 msgid "圆形"
 msgstr "圆形"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:32
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:67
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:41
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
 msgid "圆形缓入"
 msgstr "圆形缓入"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:34
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:69
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:43
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
 msgid "圆形缓入缓出"
 msgstr "圆形缓入缓出"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:33
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:68
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:42
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
 msgid "圆形缓出"
 msgstr "圆形缓出"
 
@@ -911,13 +907,13 @@ msgstr "展示小头像"
 msgid "属性"
 msgstr "属性"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:52
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:55
 msgid "左侧"
 msgstr "左侧"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:30
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:20
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:28
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:29
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:21
 msgid "左侧立绘"
 msgstr "左侧立绘"
@@ -973,7 +969,12 @@ msgstr "应用颜色变化"
 msgid "延迟时间（秒）"
 msgstr "延迟时间（秒）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:287
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:136
+msgid "开启"
+msgstr "开启"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:320
 msgid "张开嘴"
 msgstr "张开嘴"
 
@@ -1002,15 +1003,15 @@ msgstr "我确定要删除游戏"
 msgid "手动触发下一句"
 msgstr "手动触发下一句"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:57
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:61
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:91
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:63
 msgid "手动输入 ID"
 msgstr "手动输入 ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:91
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:53
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:107
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:292
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:61
 msgid "打开效果编辑器"
 msgstr "打开效果编辑器"
 
@@ -1030,12 +1031,12 @@ msgstr "拼接先前文本框内的语句"
 msgid "拼接模式"
 msgstr "拼接模式"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:97
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:100
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:265
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:267
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:65
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:113
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:116
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:298
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:300
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:70
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:73
 msgid "持续时间（单位为毫秒）"
 msgstr "持续时间（单位为毫秒）"
 
@@ -1068,7 +1069,11 @@ msgstr "提交"
 msgid "提交修改"
 msgstr "提交修改"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:42
+#: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:49
+msgid "提示"
+msgstr "提示"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:46
 msgid "提示：先设置立绘/背景，再应用动画，否则找不到目标。"
 msgstr "提示：先设置立绘/背景，再应用动画，否则找不到目标。"
 
@@ -1080,11 +1085,11 @@ msgstr "提示：在编辑结束后，如果发现有失效的鉴赏 CG/BGM ，�
 msgid "提示：换行符最多可达三行"
 msgstr "提示：换行符最多可达三行"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:382
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:133
 msgid "提示：效果只有在切换到不同背景或关闭之前的背景再重新添加时生效。如果你要为现有的背景设置效果，请使用单独的设置效果命令"
 msgstr "提示：效果只有在切换到不同背景或关闭之前的背景再重新添加时生效。如果你要为现有的背景设置效果，请使用单独的设置效果命令"
 
@@ -1124,13 +1129,13 @@ msgstr "效果与变换"
 msgid "效果声音"
 msgstr "效果声音"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:51
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:59
 msgid "效果编辑"
 msgstr "效果编辑"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:95
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:262
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:55
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:111
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:295
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:63
 msgid "效果编辑器"
 msgstr "效果编辑器"
 
@@ -1314,8 +1319,8 @@ msgstr "是否要删除 \"{gameName}\" ？"
 msgid "显示侧边栏"
 msgstr "显示侧边栏"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:88
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:256
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:104
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:289
 msgid "显示效果"
 msgstr "显示效果"
 
@@ -1323,11 +1328,11 @@ msgstr "显示效果"
 msgid "显示文本框"
 msgstr "显示文本框"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:165
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
 msgid "显示立绘"
 msgstr "显示立绘"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:63
 msgid "显示背景"
 msgstr "显示背景"
 
@@ -1355,17 +1360,17 @@ msgstr "未识别的指令"
 msgid "本句前插入句子"
 msgstr "本句前插入句子"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:73
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:182
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:79
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:203
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:142
 msgid "本句执行后执行下一句"
 msgstr "本句执行后执行下一句"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:74
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:183
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:204
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:142
 msgid "本句执行后等待"
 msgstr "本句执行后等待"
 
@@ -1601,7 +1606,7 @@ msgstr "目前没有打开任何文件"
 msgid "相对"
 msgstr "相对"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:323
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:356
 msgid "睁开眼睛"
 msgstr "睁开眼睛"
 
@@ -1650,19 +1655,19 @@ msgstr "禁用"
 msgid "立绘"
 msgstr "立绘"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:275
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:78
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:104
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:112
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:84
 msgid "立绘 ID"
 msgstr "立绘 ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:244
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:267
 msgid "立绘ID（可选）"
 msgstr "立绘ID（可选）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:234
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:257
 msgid "立绘位置"
 msgstr "立绘位置"
 
@@ -1670,7 +1675,7 @@ msgstr "立绘位置"
 msgid "立绘插图的ID"
 msgstr "立绘插图的ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:168
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:189
 msgid "立绘文件"
 msgstr "立绘文件"
 
@@ -1686,15 +1691,21 @@ msgstr "紧急回避"
 msgid "纹理"
 msgstr "纹理"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:28
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:37
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
 msgid "线性"
 msgstr "线性"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGBackgroundEditor.tsx:52
 msgid "线性渐变"
 msgstr "线性渐变"
+
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
+msgid "终点回弹"
+msgstr "终点回弹"
+
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
+msgid "终点弹跳"
+msgstr "终点弹跳"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:274
 msgid "结束后保持"
@@ -1725,13 +1736,13 @@ msgstr "绝对"
 #~ msgid "继承模式"
 #~ msgstr "继承模式"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:90
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:130
 msgid "继承现有效果"
 msgstr "继承现有效果"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:90
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:130
 msgid "继承默认效果"
 msgstr "继承默认效果"
 
@@ -1739,27 +1750,21 @@ msgstr "继承默认效果"
 #~ msgid "绿色（0-255）："
 #~ msgstr "绿色（0-255）："
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:29
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:64
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:38
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
 msgid "缓入"
 msgstr "缓入"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:31
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:66
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:40
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
 msgid "缓入缓出"
 msgstr "缓入缓出"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:30
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:65
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:39
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
 msgid "缓出"
 msgstr "缓出"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:263
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:123
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:82
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:116
 msgid "缓动类型"
 msgstr "缓动类型"
 
@@ -1816,12 +1821,12 @@ msgid "背景图像大小"
 msgstr "背景图像大小"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:23
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:31
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:32
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:24
 msgid "背景图片"
 msgstr "背景图片"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:59
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:65
 msgid "背景文件"
 msgstr "背景文件"
 
@@ -1858,7 +1863,7 @@ msgstr "自动隐藏功能区"
 msgid "自定义"
 msgstr "自定义"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:219
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "自定义 Live2D 绘制范围"
 msgstr "自定义 Live2D 绘制范围"
 
@@ -1896,8 +1901,8 @@ msgstr "获取输入"
 msgid "行脚本"
 msgstr "行脚本"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:77
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:133
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:86
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:126
 msgid "补充默认值"
 msgstr "补充默认值"
 
@@ -1946,7 +1951,7 @@ msgid "角落头像"
 msgstr "角落头像"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:85
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:92
 #: src/pages/editor/GraphicalEditor/SentenceEditor/UnlockExtra.tsx:73
 msgid "解锁名称"
 msgstr "解锁名称"
@@ -1955,7 +1960,7 @@ msgstr "解锁名称"
 msgid "解锁的 BGM 名称"
 msgstr "解锁的 BGM 名称"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:101
 msgid "解锁的 CG 名称"
 msgstr "解锁的 CG 名称"
 
@@ -2043,32 +2048,24 @@ msgstr "调用场景，新场景结束后返回父场景"
 msgid "资源"
 msgstr "资源"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:37
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
 msgid "起止回弹"
 msgstr "起止回弹"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:40
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:75
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:49
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
 msgid "起止弹跳"
 msgstr "起止弹跳"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:35
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:70
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
 msgid "起点回弹"
 msgstr "起点回弹"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:38
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:47
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
 msgid "起点弹跳"
 msgstr "起点弹跳"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:92
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:132
 msgid "跨语句动画"
 msgstr "跨语句动画"
 
@@ -2076,8 +2073,8 @@ msgstr "跨语句动画"
 msgid "软化（0-1）"
 msgstr "软化（0-1）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:70
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:96
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:74
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:104
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:76
 msgid "输入目标 ID"
 msgstr "输入目标 ID"
@@ -2098,10 +2095,10 @@ msgstr "返回"
 msgid "进出场动画"
 msgstr "进出场动画"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:69
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:178
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:108
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:75
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:199
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:138
 msgid "连续执行"
 msgstr "连续执行"
 
@@ -2109,11 +2106,11 @@ msgstr "连续执行"
 msgid "选择"
 msgstr "选择"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:45
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:49
 msgid "选择动画"
 msgstr "选择动画"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:48
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:52
 msgid "选择动画文件"
 msgstr "选择动画文件"
 
@@ -2161,18 +2158,18 @@ msgstr "选择游戏引擎版本"
 msgid "选择视频文件"
 msgstr "选择视频文件"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:161
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:171
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:290
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:302
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:314
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:182
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:192
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:323
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:335
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:347
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:359
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:371
 msgid "选择立绘文件"
 msgstr "选择立绘文件"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:53
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:62
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:59
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:68
 msgid "选择背景文件"
 msgstr "选择背景文件"
 
@@ -2205,8 +2202,8 @@ msgstr "选择退出动画文件"
 msgid "选择鉴赏资源文件"
 msgstr "选择鉴赏资源文件"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:60
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:86
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:64
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:94
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx:66
 msgid "选择预设目标"
 msgstr "选择预设目标"
@@ -2295,11 +2292,11 @@ msgstr "鉴赏资源文件"
 msgid "鉴赏音乐"
 msgstr "鉴赏音乐"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:311
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:344
 msgid "闭上嘴"
 msgstr "闭上嘴"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:335
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:368
 msgid "闭上眼睛"
 msgstr "闭上眼睛"
 
@@ -2352,9 +2349,7 @@ msgstr "音乐"
 msgid "项目主页"
 msgstr "项目主页"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:41
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:50
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
 msgid "预先反向"
 msgstr "预先反向"
 
@@ -2386,6 +2381,7 @@ msgid "高斯模糊"
 msgstr "高斯模糊"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:4
 msgid "默认"
 msgstr "默认"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -690,6 +690,24 @@ msgstr "图片"
 msgid "圆形"
 msgstr "圆形"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:32
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:67
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:41
+msgid "圆形缓入"
+msgstr "圆形缓入"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:34
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:69
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:43
+msgid "圆形缓入缓出"
+msgstr "圆形缓入缓出"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:33
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:68
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:42
+msgid "圆形缓出"
+msgstr "圆形缓出"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/editorTable.ts:59
 msgid "圆角"
 msgstr "圆角"
@@ -1668,6 +1686,12 @@ msgstr "紧急回避"
 msgid "纹理"
 msgstr "纹理"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:28
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:37
+msgid "线性"
+msgstr "线性"
+
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGBackgroundEditor.tsx:52
 msgid "线性渐变"
 msgstr "线性渐变"
@@ -1701,9 +1725,43 @@ msgstr "绝对"
 #~ msgid "继承模式"
 #~ msgstr "继承模式"
 
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+msgid "继承现有效果"
+msgstr "继承现有效果"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:81
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:137
+msgid "继承默认效果"
+msgstr "继承默认效果"
+
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:150
 #~ msgid "绿色（0-255）："
 #~ msgstr "绿色（0-255）："
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:29
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:64
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:38
+msgid "缓入"
+msgstr "缓入"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:31
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:66
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:40
+msgid "缓入缓出"
+msgstr "缓入缓出"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:30
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:65
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:39
+msgid "缓出"
+msgstr "缓出"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:85
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:263
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:123
+msgid "缓动类型"
+msgstr "缓动类型"
 
 #: src/components/IconCreator/IconCreator.tsx:625
 msgid "编辑图标"
@@ -1837,6 +1895,11 @@ msgstr "获取输入"
 #: src/pages/editor/MainArea/EditorToolbar.tsx:56
 msgid "行脚本"
 msgstr "行脚本"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:77
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:133
+msgid "补充默认值"
+msgstr "补充默认值"
 
 #: src/components/IconCreator/IconCreator.tsx:724
 msgid "裁剪形状"
@@ -1979,6 +2042,35 @@ msgstr "调用场景，新场景结束后返回父场景"
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:147
 msgid "资源"
 msgstr "资源"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:37
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
+msgid "起止回弹"
+msgstr "起止回弹"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:40
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:75
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:49
+msgid "起止弹跳"
+msgstr "起止弹跳"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:35
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:70
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
+msgid "起点回弹"
+msgstr "起点回弹"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:38
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:47
+msgid "起点弹跳"
+msgstr "起点弹跳"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:83
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
+msgid "跨语句动画"
+msgstr "跨语句动画"
 
 #: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:385
 msgid "软化（0-1）"
@@ -2259,6 +2351,12 @@ msgstr "音乐"
 #: src/pages/dashboard/About.tsx:63
 msgid "项目主页"
 msgstr "项目主页"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:41
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:76
+#: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:50
+msgid "预先反向"
+msgstr "预先反向"
 
 #: src/components/IconCreator/IconCreator.tsx:625
 msgid "预览图标"

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
@@ -14,6 +14,7 @@ import { t } from "@lingui/macro";
 import { combineSubmitString } from "@/utils/combineSubmitString";
 import { extNameMap } from "../../ChooseFile/chooseFileConfig";
 import WheelDropdown from "../components/WheelDropdown";
+import { easeType } from "../utils/constants";
 
 export default function ChangeBg(props: ISentenceEditorProps) {
   const isNoFile = props.sentence.content === "";
@@ -24,23 +25,6 @@ export default function ChangeBg(props: ISentenceEditorProps) {
   const json = useValue<string>(getArgByKey(props.sentence, 'transform') as string);
   const duration = useValue<number | string>(getArgByKey(props.sentence, 'duration') as number);
   const ease = useValue(getArgByKey(props.sentence, 'ease').toString() ?? '');
-  const easeType = new Map<string, string>([
-    [ "", t`默认` ],
-    [ "linear", t`线性` ],
-    [ "easeIn", t`缓入` ],
-    [ "easeOut", t`缓出` ],
-    [ "easeInOut", t`缓入缓出` ],
-    [ "circIn", t`圆形缓入` ],
-    [ "circOut", t`圆形缓出` ],
-    [ "circInOut", t`圆形缓入缓出` ],
-    [ "backIn", t`起点回弹` ],
-    [ "backOut", t`终点回弹` ],
-    [ "backInOut", t`起止回弹` ],
-    [ "bounceIn", t`起点弹跳` ],
-    [ "bounceOut", t`终点弹跳` ],
-    [ "bounceInOut", t`起止弹跳` ],
-    [ "anticipate", t`预先反向` ],
-  ]);
   
   const updateExpand = useEditorStore.use.updateExpand();
   const submit = () => {

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
@@ -13,6 +13,7 @@ import useEditorStore from "@/store/useEditorStore";
 import { t } from "@lingui/macro";
 import { combineSubmitString } from "@/utils/combineSubmitString";
 import { extNameMap } from "../../ChooseFile/chooseFileConfig";
+import WheelDropdown from "../components/WheelDropdown";
 
 export default function ChangeBg(props: ISentenceEditorProps) {
   const isNoFile = props.sentence.content === "";
@@ -22,6 +23,25 @@ export default function ChangeBg(props: ISentenceEditorProps) {
   const unlockSeries = useValue(getArgByKey(props.sentence, "series").toString() ?? "");
   const json = useValue<string>(getArgByKey(props.sentence, 'transform') as string);
   const duration = useValue<number | string>(getArgByKey(props.sentence, 'duration') as number);
+  const ease = useValue(getArgByKey(props.sentence, 'ease').toString() ?? '');
+  const easeType = new Map<string, string>([
+    [ "", t`默认` ],
+    [ "linear", t`线性` ],
+    [ "easeIn", t`缓入` ],
+    [ "easeOut", t`缓出` ],
+    [ "easeInOut", t`缓入缓出` ],
+    [ "circIn", t`圆形缓入` ],
+    [ "circOut", t`圆形缓出` ],
+    [ "circInOut", t`圆形缓入缓出` ],
+    [ "backIn", t`起点回弹` ],
+    [ "backOut", t`终点回弹` ],
+    [ "backInOut", t`起止回弹` ],
+    [ "bounceIn", t`起点弹跳` ],
+    [ "bounceOut", t`终点弹跳` ],
+    [ "bounceInOut", t`起止弹跳` ],
+    [ "anticipate", t`预先反向` ],
+  ]);
+  
   const updateExpand = useEditorStore.use.updateExpand();
   const submit = () => {
     const submitString = combineSubmitString(
@@ -31,10 +51,12 @@ export default function ChangeBg(props: ISentenceEditorProps) {
       [
         ...(bgFile.value !== "none" ? [
           {key: "transform", value: json.value},
+          {key: "ease", value: ease.value},
           {key: "unlockname", value: unlockName.value},
           {key: "series", value: unlockSeries.value},
         ] : [
           {key: "transform", value: ""},
+          {key: "ease", value: ""},
           {key: "unlockname", value: ""},
           {key: "series", value: ""},
         ]),
@@ -72,6 +94,16 @@ export default function ChangeBg(props: ISentenceEditorProps) {
           submit();
         }} onText={t`本句执行后执行下一句`}
         offText={t`本句执行后等待`} isChecked={isGoNext.value}/>
+      </CommonOptions>
+      <CommonOptions key="5" title={t`缓动类型`}>
+        <WheelDropdown
+          options={easeType}
+          value={ease.value}
+          onValueChange={(newValue) => {
+            ease.set(newValue?.toString() ?? "");
+            submit();
+          }}
+        />
       </CommonOptions>
       {!isNoFile && <CommonOptions key="3" title={t`解锁名称`}>
         <input value={unlockName.value}

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
@@ -16,6 +16,7 @@ import {t} from "@lingui/macro";
 import WheelDropdown from "@/pages/editor/GraphicalEditor/components/WheelDropdown";
 import { combineSubmitString, argToString } from "@/utils/combineSubmitString";
 import { extNameMap } from "../../ChooseFile/chooseFileConfig";
+import { easeType } from "../utils/constants";
 
 type FigurePosition = "" | "left" | "right";
 type AnimationFlag = "" | "on";
@@ -61,23 +62,6 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
   ]);
 
   const ease = useValue(getArgByKey(props.sentence, 'ease').toString() ?? '');
-  const easeType = new Map<string, string>([
-    [ "", t`默认` ],
-    [ "linear", t`线性` ],
-    [ "easeIn", t`缓入` ],
-    [ "easeOut", t`缓出` ],
-    [ "easeInOut", t`缓入缓出` ],
-    [ "circIn", t`圆形缓入` ],
-    [ "circOut", t`圆形缓出` ],
-    [ "circInOut", t`圆形缓入缓出` ],
-    [ "backIn", t`起点回弹` ],
-    [ "backOut", t`终点回弹` ],
-    [ "backInOut", t`起止回弹` ],
-    [ "bounceIn", t`起点弹跳` ],
-    [ "bounceOut", t`终点弹跳` ],
-    [ "bounceInOut", t`起止弹跳` ],
-    [ "anticipate", t`预先反向` ],
-  ]);
 
   useEffect(() => {
     if (figureFile.value.includes('json')) {

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
@@ -60,6 +60,25 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
     ["on", "ON"],
   ]);
 
+  const ease = useValue(getArgByKey(props.sentence, 'ease').toString() ?? '');
+  const easeType = new Map<string, string>([
+    [ "", t`默认` ],
+    [ "linear", t`线性` ],
+    [ "easeIn", t`缓入` ],
+    [ "easeOut", t`缓出` ],
+    [ "easeInOut", t`缓入缓出` ],
+    [ "circIn", t`圆形缓入` ],
+    [ "circOut", t`圆形缓出` ],
+    [ "circInOut", t`圆形缓入缓出` ],
+    [ "backIn", t`起点回弹` ],
+    [ "backOut", t`终点回弹` ],
+    [ "backInOut", t`起止回弹` ],
+    [ "bounceIn", t`起点弹跳` ],
+    [ "bounceOut", t`终点弹跳` ],
+    [ "bounceInOut", t`起止弹跳` ],
+    [ "anticipate", t`预先反向` ],
+  ]);
+
   useEffect(() => {
     if (figureFile.value.includes('json')) {
       console.log('loading JSON file to get motion and expression');
@@ -163,6 +182,7 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
         {key: "motion", value: currentMotion.value},
         {key: "expression", value: currentExpression.value},
         {key: "bounds", value: bounds.value},
+        {key: "ease", value: ease.value},
         {key: "zIndex", value: zIndex.value},
         {key: "next", value: isGoNext.value},
       ],
@@ -270,6 +290,16 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
           className={styles.sayInput}
           placeholder={t`立绘 ID`}
           style={{width: "100%"}}
+        />
+      </CommonOptions>
+      <CommonOptions key="5" title={t`缓动类型`}>
+        <WheelDropdown
+          options={easeType}
+          value={ease.value}
+          onValueChange={(newValue) => {
+            ease.set(newValue?.toString() ?? "");
+            submit();
+          }}
         />
       </CommonOptions>
       <CommonOptions key="23" title={t`显示效果`}>

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx
@@ -25,7 +25,9 @@ export default function SetAnimation(props: ISentenceEditorProps) {
   const isPresetTarget = Array.from(presetTargets.keys()).includes(target.value as PresetTarget);
   const isUsePreset = useValue(isPresetTarget);
   const isGoNext = useValue(!!getArgByKey(props.sentence, "next"));
-
+  const writeDefault = useValue(getArgByKey(props.sentence, 'writeDefault') === true);
+  const keep = useValue(getArgByKey(props.sentence, 'keep') === true);
+  
   const submit = () => {
     const submitString = combineSubmitString(
       props.sentence.commandRaw,
@@ -33,6 +35,8 @@ export default function SetAnimation(props: ISentenceEditorProps) {
       props.sentence.args,
       [
         {key: "target", value: target.value},
+        {key: "writeDefault", value: writeDefault.value},
+        {key: "keep", value: keep.value},
         {key: "next", value: isGoNext.value},
       ],
     );
@@ -79,7 +83,19 @@ export default function SetAnimation(props: ISentenceEditorProps) {
           style={{ width: "100%" }}
         />
       </CommonOptions>}
-      <CommonOptions key="5" title={t`连续执行`}>
+      <CommonOptions key="5" title={t`补充默认值`}>
+        <TerreToggle title="" onChange={(newValue) => {
+          writeDefault.set(newValue);
+          submit();
+        }} onText={t`继承默认效果`} offText={t`继承现有效果`} isChecked={writeDefault.value} />
+      </CommonOptions>
+      <CommonOptions key="6" title={t`跨语句动画`}>
+        <TerreToggle title="" onChange={(newValue) => {
+          keep.set(newValue);
+          submit();
+        }} onText={t`开启`} offText={t`关闭`} isChecked={keep.value} />
+      </CommonOptions>
+      <CommonOptions key="20" title={t`连续执行`}>
         <TerreToggle title="" onChange={(newValue) => {
           isGoNext.set(newValue);
           submit();

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
@@ -11,6 +11,7 @@ import { Button } from "@fluentui/react-components";
 import useEditorStore from "@/store/useEditorStore";
 import { t } from "@lingui/macro";
 import { combineSubmitString } from "@/utils/combineSubmitString";
+import { easeType } from "../utils/constants";
 
 type PresetTarget = "fig-left" | "fig-center" | "fig-right" | "bg-main";
 
@@ -33,23 +34,6 @@ export default function SetTransform(props: ISentenceEditorProps) {
   const isPresetTarget = Array.from(presetTargets.keys()).includes(target.value as PresetTarget);
   const isUsePreset = useValue(isPresetTarget);
   const ease = useValue(getArgByKey(props.sentence, 'ease').toString() ?? '');
-  const easeType = new Map<string, string>([
-    [ "", t`默认` ],
-    [ "linear", t`线性` ],
-    [ "easeIn", t`缓入` ],
-    [ "easeOut", t`缓出` ],
-    [ "easeInOut", t`缓入缓出` ],
-    [ "circIn", t`圆形缓入` ],
-    [ "circOut", t`圆形缓出` ],
-    [ "circInOut", t`圆形缓入缓出` ],
-    [ "backIn", t`起点回弹` ],
-    [ "backOut", t`终点回弹` ],
-    [ "backInOut", t`起止回弹` ],
-    [ "bounceIn", t`起点弹跳` ],
-    [ "bounceOut", t`终点弹跳` ],
-    [ "bounceInOut", t`起止弹跳` ],
-    [ "anticipate", t`预先反向` ],
-  ]);
   const writeDefault = useValue(getArgByKey(props.sentence, 'writeDefault') === true);
   const keep = useValue(getArgByKey(props.sentence, 'keep') === true);
 

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
@@ -32,6 +32,27 @@ export default function SetTransform(props: ISentenceEditorProps) {
   ]);
   const isPresetTarget = Array.from(presetTargets.keys()).includes(target.value as PresetTarget);
   const isUsePreset = useValue(isPresetTarget);
+  const ease = useValue(getArgByKey(props.sentence, 'ease').toString() ?? '');
+  const easeType = new Map<string, string>([
+    [ "", t`默认` ],
+    [ "linear", t`线性` ],
+    [ "easeIn", t`缓入` ],
+    [ "easeOut", t`缓出` ],
+    [ "easeInOut", t`缓入缓出` ],
+    [ "circIn", t`圆形缓入` ],
+    [ "circOut", t`圆形缓出` ],
+    [ "circInOut", t`圆形缓入缓出` ],
+    [ "backIn", t`起点回弹` ],
+    [ "backOut", t`终点回弹` ],
+    [ "backInOut", t`起止回弹` ],
+    [ "bounceIn", t`起点弹跳` ],
+    [ "bounceOut", t`终点弹跳` ],
+    [ "bounceInOut", t`起止弹跳` ],
+    [ "anticipate", t`预先反向` ],
+  ]);
+  const writeDefault = useValue(getArgByKey(props.sentence, 'writeDefault') === true);
+  const keep = useValue(getArgByKey(props.sentence, 'keep') === true);
+
   const submit = () => {
     const submitString = combineSubmitString(
       props.sentence.commandRaw,
@@ -40,6 +61,9 @@ export default function SetTransform(props: ISentenceEditorProps) {
       [
         {key: "target", value: target.value},
         {key: "duration", value: duration.value},
+        {key: "ease", value: ease.value},
+        {key: "writeDefault", value: writeDefault.value},
+        {key: "keep", value: keep.value},
         {key: "next", value: isGoNext.value},
       ],
     );
@@ -105,6 +129,28 @@ export default function SetTransform(props: ISentenceEditorProps) {
           style={{ width: "100%" }}
         />
       </CommonOptions>}
+      <CommonOptions key="5" title={t`缓动类型`}>
+        <WheelDropdown
+          options={easeType}
+          value={ease.value}
+          onValueChange={(newValue) => {
+            ease.set(newValue?.toString() ?? "");
+            submit();
+          }}
+        />
+      </CommonOptions>
+      <CommonOptions key="6" title={t`补充默认值`}>
+        <TerreToggle title="" onChange={(newValue) => {
+          writeDefault.set(newValue);
+          submit();
+        }} onText={t`继承默认效果`} offText={t`继承现有效果`} isChecked={writeDefault.value} />
+      </CommonOptions>
+      <CommonOptions key="7" title={t`跨语句动画`}>
+        <TerreToggle title="" onChange={(newValue) => {
+          keep.set(newValue);
+          submit();
+        }} onText={t`开启`} offText={t`关闭`} isChecked={keep.value} />
+      </CommonOptions>
       <CommonOptions key="20" title={t`连续执行`}>
         <TerreToggle title="" onChange={(newValue) => {
           isGoNext.set(newValue);

--- a/packages/origine2/src/pages/editor/GraphicalEditor/parser.ts
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/parser.ts
@@ -1,42 +1,8 @@
 import SceneParser from "webgal-parser";
 import { logger } from "../../../utils/logger";
 import {commandType, IScene} from "webgal-parser/src/interface/sceneInterface";
+import { SCRIPT_CONFIG } from "webgal-parser/src/config/scriptConfig";
 
-
-const SCRIPT_CONFIG = [
-  { scriptString: 'intro', scriptType: commandType.intro },
-  { scriptString: 'changeBg', scriptType: commandType.changeBg },
-  { scriptString: 'changeFigure', scriptType: commandType.changeFigure },
-  { scriptString: 'miniAvatar', scriptType: commandType.miniAvatar },
-  { scriptString: 'changeScene', scriptType: commandType.changeScene },
-  { scriptString: 'choose', scriptType: commandType.choose},
-  { scriptString: 'end', scriptType: commandType.end },
-  { scriptString: 'bgm', scriptType: commandType.bgm },
-  { scriptString: 'playVideo', scriptType: commandType.video },
-  {
-    scriptString: 'setComplexAnimation',
-    scriptType: commandType.setComplexAnimation,
-  },
-  { scriptString: 'setFilter', scriptType: commandType.setFilter },
-  { scriptString: 'pixiInit', scriptType: commandType.pixiInit },
-  { scriptString: 'pixiPerform', scriptType: commandType.pixi },
-  { scriptString: 'label', scriptType: commandType.label},
-  { scriptString: 'jumpLabel', scriptType: commandType.jumpLabel},
-  { scriptString: 'setVar', scriptType: commandType.setVar },
-  { scriptString: 'callScene', scriptType: commandType.callScene },
-  { scriptString: 'showVars', scriptType: commandType.showVars },
-  { scriptString: 'unlockCg', scriptType: commandType.unlockCg },
-  { scriptString: 'unlockBgm', scriptType: commandType.unlockBgm },
-  { scriptString: 'say', scriptType: commandType.say },
-  { scriptString: 'filmMode', scriptType: commandType.filmMode },
-  { scriptString: 'callScene', scriptType: commandType.callScene },
-  { scriptString: 'setTextbox', scriptType: commandType.setTextbox},
-  { scriptString: 'setAnimation', scriptType: commandType.setAnimation },
-  { scriptString: 'playEffect', scriptType: commandType.playEffect },
-  { scriptString: 'setTransition', scriptType: commandType.setTransition },
-  { scriptString: 'setTransform', scriptType: commandType.setTransform },
-  { scriptString: 'getUserInput', scriptType: commandType.getUserInput },
-];
 
 export const WebgalParser = new SceneParser(() => {
 }, (fileName, assetType) => {

--- a/packages/origine2/src/pages/editor/GraphicalEditor/utils/constants.ts
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/utils/constants.ts
@@ -1,0 +1,19 @@
+import { t } from "@lingui/macro";
+
+export const easeType = new Map<string, string>([
+  [ "", t`默认` ],
+  [ "linear", t`线性` ],
+  [ "easeIn", t`缓入` ],
+  [ "easeOut", t`缓出` ],
+  [ "easeInOut", t`缓入缓出` ],
+  [ "circIn", t`圆形缓入` ],
+  [ "circOut", t`圆形缓出` ],
+  [ "circInOut", t`圆形缓入缓出` ],
+  [ "backIn", t`起点回弹` ],
+  [ "backOut", t`终点回弹` ],
+  [ "backInOut", t`起止回弹` ],
+  [ "bounceIn", t`起点弹跳` ],
+  [ "bounceOut", t`终点弹跳` ],
+  [ "bounceInOut", t`起止弹跳` ],
+  [ "anticipate", t`预先反向` ],
+]);

--- a/packages/origine2/src/utils/combineSubmitString.ts
+++ b/packages/origine2/src/utils/combineSubmitString.ts
@@ -9,38 +9,38 @@ import { arg } from "webgal-parser/src/interface/sceneInterface";
  * @returns 合并后的用于提交的字符串
  */
 export function combineSubmitString (
-    commandStr: string | undefined,
-    content: string,
-    originalArgs: Array<arg>,
-    newArgs: Array<{key: string, value: string | boolean | number, fullMode?: boolean}>
+  commandStr: string | undefined,
+  content: string,
+  originalArgs: Array<arg>,
+  newArgs: Array<{key: string, value: string | boolean | number, fullMode?: boolean}>
 ): string {
-    const argStrings: Array<string> = [];
-    const combinedArg = new Map<string, string | boolean | number>()
+  const argStrings: Array<string> = [];
+  const combinedArg = new Map<string, string | boolean | number>();
 
-    originalArgs.forEach(oArg => combinedArg.set(oArg.key, oArg.value));
-    newArgs.forEach((nArg) => {
-        if (!nArg.fullMode && (nArg.value === true || nArg.value === false || nArg.value === "")) {
-            combinedArg.delete(nArg.key);
-            if (nArg.value === "") {
-                nArg.value = false;
-            }
-            argStrings.push(argToSimplifiedString(nArg.key, nArg.value));
-        } else {
-            combinedArg.set(nArg.key, nArg.value)
-        }
-    });
-
-    combinedArg.forEach((v, k, m) => {
-        argStrings.push(argToString(k, v));
-    });
-    
-    let combinedString = "";
-    if (commandStr === "" || commandStr) {
-        combinedString += `${commandStr}:`
+  originalArgs.forEach(oArg => combinedArg.set(oArg.key, oArg.value));
+  newArgs.forEach((nArg) => {
+    if (!nArg.fullMode && (nArg.value === true || nArg.value === false || nArg.value === "")) {
+      combinedArg.delete(nArg.key);
+      if (nArg.value === "") {
+        nArg.value = false;
+      }
+      argStrings.push(argToSimplifiedString(nArg.key, nArg.value));
+    } else {
+      combinedArg.set(nArg.key, nArg.value);
     }
-    combinedString += `${content}${argStrings.join("")};`;
+  });
 
-    return combinedString;
+  combinedArg.forEach((v, k, m) => {
+    argStrings.push(argToString(k, v));
+  });
+    
+  let combinedString = "";
+  if (commandStr === "" || commandStr) {
+    combinedString += `${commandStr}:`;
+  }
+  combinedString += `${content}${argStrings.join("")};`;
+
+  return combinedString;
 }
 
 /**
@@ -50,10 +50,10 @@ export function combineSubmitString (
  * @returns 转换后的字符串
  */
 export function argToString(
-    key: string,
-    value: string | boolean | number,
+  key: string,
+  value: string | boolean | number,
 ): string {
-    return ` -${key}=${value}`;
+  return ` -${key}=${value}`;
 }
 
 /**
@@ -63,12 +63,12 @@ export function argToString(
  * @returns 转换后的字符串
  */
 export function argToSimplifiedString(
-    key: string,
-    value: boolean,
+  key: string,
+  value: boolean,
 ): string {
-    if (value) {
-        return ` -${key}`;
-    } else {
-        return ``;
-    }
+  if (value) {
+    return ` -${key}`;
+  } else {
+    return ``;
+  }
 }

--- a/packages/terre2/src/Modules/lsp/suggestionRules/getArgsKey.ts
+++ b/packages/terre2/src/Modules/lsp/suggestionRules/getArgsKey.ts
@@ -27,6 +27,9 @@ export function getArgsKey(
         transformKey,
         unlocknameKey,
         seriesKey,
+        enterAnimationKey,
+        exitAnimationKey,
+        easeKey,
       ];
     }
     case commandType.choose: {
@@ -57,6 +60,9 @@ export function getArgsKey(
         mouthOpenKey,
         mouthHalfOpenKey,
         mouthCloseKey,
+        enterAnimationKey,
+        exitAnimationKey,
+        easeKey,
       ];
     }
     case commandType.intro: {
@@ -78,10 +84,33 @@ export function getArgsKey(
       return [whenKey, skipOffKey];
     }
     case commandType.setAnimation: {
-      return [whenKey, nextKey, targetKey];
+      return [
+        whenKey,
+        nextKey,
+        targetKey,
+        writeDefaultKey,
+        keepKey,
+      ];
+    }
+    case commandType.setTempAnimation: {
+      return [
+        whenKey,
+        nextKey,
+        targetKey,
+        writeDefaultKey,
+        keepKey,
+      ];
     }
     case commandType.setTransform: {
-      return [whenKey, nextKey, targetKey, durationKey];
+      return [
+        whenKey,
+        nextKey,
+        targetKey,
+        easeKey,
+        writeDefaultKey,
+        keepKey,
+        durationKey,
+      ];
     }
     case commandType.setTransition: {
       return [whenKey, targetKey, enterAnimationKey, exitAnimationKey];
@@ -511,6 +540,52 @@ const targetKey: CompletionItem = {
   detail: '指定目标',
   documentation: markdown(`
 将动画或效果应用于指定目标
+  `),
+};
+
+const easeKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'ease',
+  insertText: 'ease=',
+  detail: '缓动类型',
+  documentation: markdown(`
+为动画设置缓动类型
+可用的缓动类型有
+- linear
+- anticipate
+- easeIn
+- easeOut
+- easeInOut (默认值)
+- circIn
+- circOut
+- circInOut
+- backIn
+- backOut
+- backInOut
+- bounceIn
+- bounceOut
+- bounceInOut
+  `),
+};
+
+const writeDefaultKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'writeDefault',
+  insertText: 'writeDefault=',
+  detail: '补充默认值',
+  documentation: markdown(`
+若变换与效果中有未填写的属性时, 补充默认值, 否则继承现有的值
+  `),
+};
+
+const keepKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'keep',
+  insertText: 'keep=',
+  detail: '跨语句动画',
+  documentation: markdown(`
+开启后, 动画可以跨对话播放, 直至被下一个同目标的
+\`setTransform\` \`setAnimation\` \`setTempAnimation\` 打断
   `),
 };
 

--- a/packages/terre2/src/Modules/lsp/suggestionRules/getArgsKey.ts
+++ b/packages/terre2/src/Modules/lsp/suggestionRules/getArgsKey.ts
@@ -84,22 +84,10 @@ export function getArgsKey(
       return [whenKey, skipOffKey];
     }
     case commandType.setAnimation: {
-      return [
-        whenKey,
-        nextKey,
-        targetKey,
-        writeDefaultKey,
-        keepKey,
-      ];
+      return [whenKey, nextKey, targetKey, writeDefaultKey, keepKey];
     }
     case commandType.setTempAnimation: {
-      return [
-        whenKey,
-        nextKey,
-        targetKey,
-        writeDefaultKey,
-        keepKey,
-      ];
+      return [whenKey, nextKey, targetKey, writeDefaultKey, keepKey];
     }
     case commandType.setTransform: {
       return [


### PR DESCRIPTION
# 介绍
增添 `ease` `writeDefault` `keep` 的图形选项与代码补全

~~**_注_** 此 PR 的参数写法是原始方法, 未与 #425 保持一致, 如果 #425 先于此 PR 合并在这里@我~~ 已对齐
**_注2_** 似乎是由于 `webgal-parser` 模组许久未更新, `setTransform` `setTempAnimation` 的补全不能生效