### PR TITLE
fix: missing ease type locale

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -622,7 +622,7 @@ msgstr "New version detected"
 
 #: src/components/ColorPickerPopup/ColorPickerPopup.tsx:115
 #: src/components/IconCreator/IconCreator.tsx:770
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:59
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:67
 #: src/pages/templateEditor/TemplateEditorSidebar/TemplateEditorSidebar.tsx:171
 msgid "取消"
 msgstr "Cancel"
@@ -690,15 +690,15 @@ msgstr "Image"
 msgid "圆形"
 msgstr "Circle"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
 msgid "圆形缓入"
 msgstr "Circ in"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
 msgid "圆形缓入缓出"
 msgstr "Circ in out"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
 msgid "圆形缓出"
 msgstr "Circ out"
 
@@ -1693,7 +1693,7 @@ msgstr "Emergency Evasion"
 msgid "纹理"
 msgstr "Texture"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
 msgid "线性"
 msgstr "Linear"
 
@@ -1701,11 +1701,11 @@ msgstr "Linear"
 msgid "线性渐变"
 msgstr "Linear gradient"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
 msgid "终点回弹"
 msgstr "Back out"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
 msgid "终点弹跳"
 msgstr "Bounce out"
 
@@ -1752,15 +1752,15 @@ msgstr "Inherit default effect"
 #~ msgid "绿色（0-255）："
 #~ msgstr "Green (0-255)"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
 msgid "缓入"
 msgstr "Ease in"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
 msgid "缓入缓出"
 msgstr "Ease in out"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
 msgid "缓出"
 msgstr "Ease out"
 
@@ -2050,19 +2050,19 @@ msgstr "Call scene, return to parent scene after new scene ends"
 msgid "资源"
 msgstr "Assets"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
 msgid "起止回弹"
 msgstr "Back in out"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
 msgid "起止弹跳"
 msgstr "Bounce in out"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
 msgid "起点回弹"
 msgstr "Back in"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
 msgid "起点弹跳"
 msgstr "Bounce in"
 
@@ -2108,7 +2108,7 @@ msgstr "Entry and exit animation"
 msgid "连续执行"
 msgstr "Execute Continuously"
 
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:59
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:67
 msgid "选择"
 msgstr "Choose"
 
@@ -2152,7 +2152,7 @@ msgstr "Select apply template"
 msgid "选择效果音文件"
 msgstr "Choose sound effect file"
 
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:65
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:73
 msgid "选择文件"
 msgstr "Choose file"
 
@@ -2355,7 +2355,7 @@ msgstr "Music"
 msgid "项目主页"
 msgstr "Project Homepage"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:19
 msgid "预先反向"
 msgstr "Anticipate"
 
@@ -2387,7 +2387,7 @@ msgid "高斯模糊"
 msgstr "Gaussian Blur"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:4
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
 msgid "默认"
 msgstr "Default"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -625,7 +625,7 @@ msgstr "新しいバージョンが検出されました"
 
 #: src/components/ColorPickerPopup/ColorPickerPopup.tsx:115
 #: src/components/IconCreator/IconCreator.tsx:770
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:59
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:67
 #: src/pages/templateEditor/TemplateEditorSidebar/TemplateEditorSidebar.tsx:171
 msgid "取消"
 msgstr "キャンセル"
@@ -693,15 +693,15 @@ msgstr "画像"
 msgid "圆形"
 msgstr "円形"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
 msgid "圆形缓入"
 msgstr "サークイン"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
 msgid "圆形缓入缓出"
 msgstr "サークインアウト"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
 msgid "圆形缓出"
 msgstr "サークアウト"
 
@@ -1692,7 +1692,7 @@ msgstr "緊急回避"
 msgid "纹理"
 msgstr "Tex"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
 msgid "线性"
 msgstr "リニア"
 
@@ -1700,11 +1700,11 @@ msgstr "リニア"
 msgid "线性渐变"
 msgstr "線形グラデーション"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
 msgid "终点回弹"
 msgstr "バックアウト"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
 msgid "终点弹跳"
 msgstr "バウンスアウト"
 
@@ -1751,15 +1751,15 @@ msgstr "デフォルトの効果を継承する"
 #~ msgid "绿色（0-255）："
 #~ msgstr "緑(0-255):"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
 msgid "缓入"
 msgstr "イーズイン"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
 msgid "缓入缓出"
 msgstr "イーズインアウト"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
 msgid "缓出"
 msgstr "イーズアウト"
 
@@ -2049,19 +2049,19 @@ msgstr "シーンを呼び出し、新しいシーン終了後に親シーンに
 msgid "资源"
 msgstr "アセット"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
 msgid "起止回弹"
 msgstr "バックインアウト"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
 msgid "起止弹跳"
 msgstr "バウンスインアウト"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
 msgid "起点回弹"
 msgstr "バックイン"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
 msgid "起点弹跳"
 msgstr "バウンスイン"
 
@@ -2107,7 +2107,7 @@ msgstr "入退場アニメーション"
 msgid "连续执行"
 msgstr "連続実行"
 
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:59
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:67
 msgid "选择"
 msgstr "選択"
 
@@ -2151,7 +2151,7 @@ msgstr "適用テンプレートを選択"
 msgid "选择效果音文件"
 msgstr "効果音ファイルを選択"
 
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:65
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:73
 msgid "选择文件"
 msgstr "ファイルを選択"
 
@@ -2354,7 +2354,7 @@ msgstr "BGM"
 msgid "项目主页"
 msgstr "プロジェクトホームページ"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:19
 msgid "预先反向"
 msgstr "アンティシペート"
 
@@ -2386,7 +2386,7 @@ msgid "高斯模糊"
 msgstr "ぼかし"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:4
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
 msgid "默认"
 msgstr "デフォルト"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -624,7 +624,7 @@ msgstr "发现新版本"
 
 #: src/components/ColorPickerPopup/ColorPickerPopup.tsx:115
 #: src/components/IconCreator/IconCreator.tsx:770
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:59
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:67
 #: src/pages/templateEditor/TemplateEditorSidebar/TemplateEditorSidebar.tsx:171
 msgid "取消"
 msgstr "取消"
@@ -692,15 +692,15 @@ msgstr "图片"
 msgid "圆形"
 msgstr "圆形"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
 msgid "圆形缓入"
 msgstr "圆形缓入"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
 msgid "圆形缓入缓出"
 msgstr "圆形缓入缓出"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:10
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:11
 msgid "圆形缓出"
 msgstr "圆形缓出"
 
@@ -1691,7 +1691,7 @@ msgstr "紧急回避"
 msgid "纹理"
 msgstr "纹理"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
 msgid "线性"
 msgstr "线性"
 
@@ -1699,11 +1699,11 @@ msgstr "线性"
 msgid "线性渐变"
 msgstr "线性渐变"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
 msgid "终点回弹"
 msgstr "终点回弹"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
 msgid "终点弹跳"
 msgstr "终点弹跳"
 
@@ -1750,15 +1750,15 @@ msgstr "继承默认效果"
 #~ msgid "绿色（0-255）："
 #~ msgstr "绿色（0-255）："
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:6
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
 msgid "缓入"
 msgstr "缓入"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:9
 msgid "缓入缓出"
 msgstr "缓入缓出"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:7
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:8
 msgid "缓出"
 msgstr "缓出"
 
@@ -2048,19 +2048,19 @@ msgstr "调用场景，新场景结束后返回父场景"
 msgid "资源"
 msgstr "资源"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:14
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
 msgid "起止回弹"
 msgstr "起止回弹"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:17
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
 msgid "起止弹跳"
 msgstr "起止弹跳"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:12
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:13
 msgid "起点回弹"
 msgstr "起点回弹"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:15
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:16
 msgid "起点弹跳"
 msgstr "起点弹跳"
 
@@ -2106,7 +2106,7 @@ msgstr "进出场动画"
 msgid "连续执行"
 msgstr "连续执行"
 
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:59
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:67
 msgid "选择"
 msgstr "选择"
 
@@ -2150,7 +2150,7 @@ msgstr "选择应用的模板"
 msgid "选择效果音文件"
 msgstr "选择效果音文件"
 
-#: src/pages/editor/ChooseFile/ChooseFile.tsx:65
+#: src/pages/editor/ChooseFile/ChooseFile.tsx:73
 msgid "选择文件"
 msgstr "选择文件"
 
@@ -2353,7 +2353,7 @@ msgstr "音乐"
 msgid "项目主页"
 msgstr "项目主页"
 
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:18
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:19
 msgid "预先反向"
 msgstr "预先反向"
 
@@ -2385,7 +2385,7 @@ msgid "高斯模糊"
 msgstr "高斯模糊"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
-#: src/pages/editor/GraphicalEditor/utils/constants.ts:4
+#: src/pages/editor/GraphicalEditor/utils/constants.ts:5
 msgid "默认"
 msgstr "默认"
 

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
@@ -14,7 +14,7 @@ import { t } from "@lingui/macro";
 import { combineSubmitString } from "@/utils/combineSubmitString";
 import { extNameMap } from "../../ChooseFile/chooseFileConfig";
 import WheelDropdown from "../components/WheelDropdown";
-import { easeType } from "../utils/constants";
+import { getEaseType } from "../utils/constants";
 
 export default function ChangeBg(props: ISentenceEditorProps) {
   const isNoFile = props.sentence.content === "";
@@ -81,7 +81,7 @@ export default function ChangeBg(props: ISentenceEditorProps) {
       </CommonOptions>
       <CommonOptions key="5" title={t`缓动类型`}>
         <WheelDropdown
-          options={easeType}
+          options={getEaseType()}
           value={ease.value}
           onValueChange={(newValue) => {
             ease.set(newValue?.toString() ?? "");

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
@@ -16,7 +16,7 @@ import {t} from "@lingui/macro";
 import WheelDropdown from "@/pages/editor/GraphicalEditor/components/WheelDropdown";
 import { combineSubmitString, argToString } from "@/utils/combineSubmitString";
 import { extNameMap } from "../../ChooseFile/chooseFileConfig";
-import { easeType } from "../utils/constants";
+import { getEaseType } from "../utils/constants";
 
 type FigurePosition = "" | "left" | "right";
 type AnimationFlag = "" | "on";
@@ -278,7 +278,7 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
       </CommonOptions>
       <CommonOptions key="5" title={t`缓动类型`}>
         <WheelDropdown
-          options={easeType}
+          options={getEaseType()}
           value={ease.value}
           onValueChange={(newValue) => {
             ease.set(newValue?.toString() ?? "");

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
@@ -11,7 +11,7 @@ import { Button } from "@fluentui/react-components";
 import useEditorStore from "@/store/useEditorStore";
 import { t } from "@lingui/macro";
 import { combineSubmitString } from "@/utils/combineSubmitString";
-import { easeType } from "../utils/constants";
+import { getEaseType } from "../utils/constants";
 
 type PresetTarget = "fig-left" | "fig-center" | "fig-right" | "bg-main";
 
@@ -115,7 +115,7 @@ export default function SetTransform(props: ISentenceEditorProps) {
       </CommonOptions>}
       <CommonOptions key="5" title={t`缓动类型`}>
         <WheelDropdown
-          options={easeType}
+          options={getEaseType()}
           value={ease.value}
           onValueChange={(newValue) => {
             ease.set(newValue?.toString() ?? "");

--- a/packages/origine2/src/pages/editor/GraphicalEditor/utils/constants.ts
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/utils/constants.ts
@@ -1,19 +1,21 @@
 import { t } from "@lingui/macro";
 
-export const easeType = new Map<string, string>([
-  [ "", t`默认` ],
-  [ "linear", t`线性` ],
-  [ "easeIn", t`缓入` ],
-  [ "easeOut", t`缓出` ],
-  [ "easeInOut", t`缓入缓出` ],
-  [ "circIn", t`圆形缓入` ],
-  [ "circOut", t`圆形缓出` ],
-  [ "circInOut", t`圆形缓入缓出` ],
-  [ "backIn", t`起点回弹` ],
-  [ "backOut", t`终点回弹` ],
-  [ "backInOut", t`起止回弹` ],
-  [ "bounceIn", t`起点弹跳` ],
-  [ "bounceOut", t`终点弹跳` ],
-  [ "bounceInOut", t`起止弹跳` ],
-  [ "anticipate", t`预先反向` ],
-]);
+export const getEaseType = (): Map<string, string> => {
+  return new Map<string, string>([
+    [ "", t`默认` ],
+    [ "linear", t`线性` ],
+    [ "easeIn", t`缓入` ],
+    [ "easeOut", t`缓出` ],
+    [ "easeInOut", t`缓入缓出` ],
+    [ "circIn", t`圆形缓入` ],
+    [ "circOut", t`圆形缓出` ],
+    [ "circInOut", t`圆形缓入缓出` ],
+    [ "backIn", t`起点回弹` ],
+    [ "backOut", t`终点回弹` ],
+    [ "backInOut", t`起止回弹` ],
+    [ "bounceIn", t`起点弹跳` ],
+    [ "bounceOut", t`终点弹跳` ],
+    [ "bounceInOut", t`起止弹跳` ],
+    [ "anticipate", t`预先反向` ],
+  ]);
+}


### PR DESCRIPTION
# 介绍
fix #443
修复 `easeType` 的翻译无法生效的问题

# 主要更改
- 将常量 `easeType` 改为函数 `getEaseType()` , 每次调用返回新 `Map<string, string>`, ~~虽然从性能角度考虑属下策,~~