### PR TITLE
feat: add dark theme

### DIFF
--- a/packages/origine2/public/monaco-iframe/monaco.html
+++ b/packages/origine2/public/monaco-iframe/monaco.html
@@ -22,7 +22,9 @@
   require(['vs/editor/editor.main'], function () {
     var editor = monaco.editor.create(document.getElementById('container'), {
       value: '',
-      language: 'js' // 初始化语言为 javascript，可以根据需要修改
+      language: 'js',  // 初始化语言为 javascript，可以根据需要修改
+      automaticLayout: true,
+      wordWrap: 'on',
     });
 
     // 通知父窗口 editor 已经准备好
@@ -48,6 +50,9 @@
               {range: editor.getModel().getFullModelRange(), text: message.value}
             ]);
           }
+          break;
+        case 'setTheme':
+          monaco.editor.setTheme(message.theme);
           break;
       }
     });

--- a/packages/origine2/src/config/highlighting/hl.json
+++ b/packages/origine2/src/config/highlighting/hl.json
@@ -99,7 +99,7 @@
               ]
             },
             "3": {
-              "name": "markup.quote"
+              "name": "variable.other.webgal"
             }
           }
         }

--- a/packages/origine2/src/config/themes/light-vs.json
+++ b/packages/origine2/src/config/themes/light-vs.json
@@ -37,69 +37,6 @@
   "tokenColors": [
     {
       "scope": [
-        "keyword.operator.webgal"
-      ],
-      "settings": {
-        "foreground": "#f9005a",
-        "fontStyle": "bold"
-      }
-    },
-    {
-      "scope": [
-        "keyword.operator.webgal"
-      ],
-      "settings": {
-        "foreground": "#f9005a",
-        "fontStyle": "bold"
-      }
-    },
-    {
-      "scope": [
-        "string.unquoted.utterance.webgal"
-      ],
-      "settings": {
-        "foreground": "#998f2f",
-        "fontStyle": "bold"
-      }
-    },
-    {
-      "scope": [
-        "meta.command.webgal",
-        "support.function.command.webgal"
-      ],
-      "settings": {
-        "foreground": "#f9005a",
-        "fontStyle": "bold"
-      }
-    },
-    {
-      "scope": [
-        "meta.character.webgal",
-        "entity.name.type.character.webgal"
-      ],
-      "settings": {
-        "foreground": "#684d99",
-        "fontStyle": "bold"
-      }
-    },
-    {
-      "scope": [
-        "variable.parameter.webgal",
-      ],
-      "settings": {
-        "foreground": "#cf7000",
-      }
-    },
-    {
-      "scope": [
-        "variable.other.webgal",
-      ],
-      "settings": {
-        "foreground": "#000000",
-      }
-    },
-    {
-      "scope": [
         "meta.embedded",
         "source.groovy.embedded",
         "string meta.image.inline.markdown",
@@ -125,15 +62,6 @@
       "scope": "meta.diff.header",
       "settings": {
         "foreground": "#000080"
-      }
-    },
-    {
-      "scope": [
-        "comment",
-        "comment.line.webgal"
-      ],
-      "settings": {
-        "foreground": "#999999"
       }
     },
     {

--- a/packages/origine2/src/config/themes/monokai-light-vs.json
+++ b/packages/origine2/src/config/themes/monokai-light-vs.json
@@ -4,13 +4,77 @@
   "colors": {
     "editor.background": "#fafafa",
     "editor.lineHighlightBackground": "#e6e3c3",
-    "editor.selectionBackground": "#ccc9ad",
+    "editor.selectionBackground": "#ccc9ad8e",
+    "editor.wordHighlightBackground": "#00000011",
     "editorCursor.foreground": "#666663",
     "editorIndentGuide.background": "#D3D4D5",
     "editorLineNumber.foreground": "#a2a19c",
     "editorWhitespace.foreground": "#bbbbb7"
   },
   "tokenColors": [
+    {
+      "scope": [
+        "comment",
+        "comment.line.webgal"
+      ],
+      "settings": {
+        "foreground": "#999999"
+      }
+    },
+		{
+      "scope": [
+        "keyword.operator.webgal"
+      ],
+      "settings": {
+        "foreground": "#ff2c80",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "string.unquoted.utterance.webgal"
+      ],
+      "settings": {
+        "foreground": "#aca21a",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "meta.command.webgal",
+        "support.function.command.webgal"
+      ],
+      "settings": {
+        "foreground": "#0075d4",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "meta.character.webgal",
+        "entity.name.type.character.webgal"
+      ],
+      "settings": {
+        "foreground": "#8db118",
+				"fontStyle": "bold underline"
+      }
+    },
+    {
+      "scope": [
+        "variable.parameter.webgal",
+      ],
+      "settings": {
+        "foreground": "#d88a14",
+      }
+    },
+    {
+      "scope": [
+        "variable.other.webgal",
+      ],
+      "settings": {
+        "foreground": "#16c441",
+      }
+    },
     {
       "settings": {
         "background": "#fafafa",

--- a/packages/origine2/src/config/themes/theme.css
+++ b/packages/origine2/src/config/themes/theme.css
@@ -70,3 +70,64 @@
     --shadow-primary-md: 0 1px 2px var(--primary-10pct);
     --shadow-primary-lg: 0 2px 4px var(--primary-10pct);
 }
+
+.monaco-list-row:hover:not(.focused) {
+    background-color: var(--black-10pct) !important;
+}
+
+:root.dark {
+    --black: rgb(255, 255, 255);
+    --black-0pct: rgba(255, 255, 255, 0);
+    --black-5pct: rgba(255, 255, 255, 0.05);
+    --black-7pct: rgba(255, 255, 255, 0.07);
+    --black-10pct: rgba(255, 255, 255, 0.1);
+    --black-15pct: rgba(255, 255, 255, 0.15);
+    --black-35pct: rgba(255, 255, 255, 0.35);
+    --black-50pct: rgba(255, 255, 255, 0.5);
+    --black-75pct: rgba(255, 255, 255, 0.75);
+    --gray-dark: rgba(205, 208, 213, 1);
+    --gray-51: rgba(204, 204, 204, 1);
+    --gray-102: rgba(153, 153, 153, 1);
+    --gray-153: rgba(102, 102, 102, 1);
+    --gray-204: rgba(51, 51, 51, 1);
+    --gray-242: rgba(13, 13, 13, 1);
+    --gray-245: rgba(10, 10, 10, 1);
+    --gray-248: rgba(8, 8, 8, 1);
+    --blue-deep: rgba(122, 190, 255, 1);
+    --blue-deep-20pct: rgba(122, 190, 255, 0.2);
+    --blue-light: rgba(0, 128, 163, 1);
+    --blue-ultra-light: rgba(0, 3, 10, 1);
+    --blue-medium: rgba(133, 196, 255, 1);
+    --blue-medium-10pct: rgba(133, 196, 255, 0.1);
+    --blue-sky-50pct: rgba(128, 184, 255, 0.5);
+    --blue-navy: rgba(199, 223, 255, 1);
+    --white: rgb(0, 0, 0);
+
+    --primary: rgb(89, 178, 255);
+    --primary-5pct: rgba(89, 178, 255, 0.05);
+    --primary-10pct: rgba(89, 178, 255, 0.1);
+    --primary-90pct: rgba(89, 178, 255, 0.9);
+    --text: rgb(223, 223, 223);
+    --text-sub: rgb(150, 150, 150);
+    --text-weak: rgb(123, 123, 123);
+    --bg-base: rgb(0, 0, 0);
+    --bg-root: rgb(24, 24, 24);
+    --bg-card: rgb(30, 30, 30);
+    --bg-button: rgb(40, 40, 40);
+    --bg-input: rgb(40, 40, 40);
+}
+
+:root.dark ::-webkit-scrollbar {
+    width: 8px;
+    background: var(--bg-scrollbar);
+}
+:root.dark ::-webkit-scrollbar-thumb {
+    background: var(--bg-scrollbar-thumb);
+    border-radius: 4px;
+}
+:root.dark ::-webkit-scrollbar-thumb:hover {
+    background: var(--bg-scrollbar-thumb-hover);
+}
+:root.dark ::-webkit-scrollbar-corner {
+    background: var(--bg-scrollbar);
+}

--- a/packages/origine2/src/config/themes/vscode-dark-modern.json
+++ b/packages/origine2/src/config/themes/vscode-dark-modern.json
@@ -1,0 +1,780 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Dark (Visual Studio)",
+	"colors": {
+		"editor.inactiveSelectionBackground": "#3a3d4186",
+		"editorIndentGuide.background1": "#404040",
+		"editorIndentGuide.activeBackground1": "#707070",
+		"editor.selectionHighlightBackground": "#ADD6FF26",
+		"editor.lineHighlightBackground": "#338bff15",
+		"editor.lineHighlightBorder": "#00000000",
+		"editor.selectionBackground": "#338bff45",
+		"editorCursor.foreground": "#ffffff",
+		"list.dropBackground": "#383B3D",
+		"menu.foreground": "#CCCCCC",
+		"menu.separatorBackground": "#454545",
+		"menu.border": "#454545",
+		"tab.selectedBackground": "#222222",
+		"tab.selectedForeground": "#ffffffa0",
+		"tab.lastPinnedBorder": "#ccc3",
+		"list.activeSelectionIconForeground": "#FFF",
+		"terminal.inactiveSelectionBackground": "#3A3D41",
+		"actionBar.toggledBackground": "#383a49",
+		"activityBar.activeBorder": "#0078D4",
+		"activityBar.background": "#181818",
+		"activityBar.border": "#2B2B2B",
+		"activityBar.foreground": "#D7D7D7",
+		"activityBar.inactiveForeground": "#868686",
+		"activityBarBadge.background": "#0078D4",
+		"activityBarBadge.foreground": "#FFFFFF",
+		"badge.background": "#616161",
+		"badge.foreground": "#F8F8F8",
+		"button.background": "#0078D4",
+		"button.border": "#FFFFFF12",
+		"button.foreground": "#FFFFFF",
+		"button.hoverBackground": "#026EC1",
+		"button.secondaryBackground": "#313131",
+		"button.secondaryForeground": "#CCCCCC",
+		"button.secondaryHoverBackground": "#3C3C3C",
+		"chat.slashCommandBackground": "#26477866",
+		"chat.slashCommandForeground": "#85B6FF",
+		"chat.editedFileForeground": "#E2C08D",
+		"checkbox.background": "#313131",
+		"checkbox.border": "#3C3C3C",
+		"debugToolBar.background": "#181818",
+		"descriptionForeground": "#9D9D9D",
+		"dropdown.background": "#313131",
+		"dropdown.border": "#3C3C3C",
+		"dropdown.foreground": "#CCCCCC",
+		"dropdown.listBackground": "#1F1F1F",
+		"editor.background": "#1F1F1F",
+		"editor.findMatchBackground": "#9E6A03",
+		"editor.foreground": "#CCCCCC",
+		"editorGroup.border": "#FFFFFF17",
+		"editorGroupHeader.tabsBackground": "#181818",
+		"editorGroupHeader.tabsBorder": "#2B2B2B",
+		"editorGutter.addedBackground": "#2EA043",
+		"editorGutter.deletedBackground": "#F85149",
+		"editorGutter.modifiedBackground": "#0078D4",
+		"editorLineNumber.activeForeground": "#CCCCCC",
+		"editorLineNumber.foreground": "#6E7681",
+		"editorOverviewRuler.border": "#010409",
+		"editorWidget.background": "#202020",
+		"errorForeground": "#F85149",
+		"focusBorder": "#0078D4",
+		"foreground": "#CCCCCC",
+		"icon.foreground": "#CCCCCC",
+		"input.background": "#313131",
+		"input.border": "#3C3C3C",
+		"input.foreground": "#CCCCCC",
+		"input.placeholderForeground": "#989898",
+		"inputOption.activeBackground": "#2489DB82",
+		"inputOption.activeBorder": "#2488DB",
+		"keybindingLabel.foreground": "#CCCCCC",
+		"menu.background": "#1F1F1F",
+		"menu.selectionBackground": "#0078d470",
+		"notificationCenterHeader.background": "#1F1F1F",
+		"notificationCenterHeader.foreground": "#CCCCCC",
+		"notifications.background": "#1F1F1F",
+		"notifications.border": "#2B2B2B",
+		"notifications.foreground": "#CCCCCC",
+		"panel.background": "#181818",
+		"panel.border": "#2B2B2B",
+		"panelInput.border": "#2B2B2B",
+		"panelTitle.activeBorder": "#0078D4",
+		"panelTitle.activeForeground": "#CCCCCC",
+		"panelTitle.inactiveForeground": "#9D9D9D",
+		"peekViewEditor.background": "#1F1F1F",
+		"peekViewEditor.matchHighlightBackground": "#BB800966",
+		"peekViewResult.background": "#1F1F1F",
+		"peekViewResult.matchHighlightBackground": "#BB800966",
+		"pickerGroup.border": "#3C3C3C",
+		"progressBar.background": "#0078D4",
+		"quickInput.background": "#222222",
+		"quickInput.foreground": "#CCCCCC",
+		"settings.dropdownBackground": "#313131",
+		"settings.dropdownBorder": "#3C3C3C",
+		"settings.headerForeground": "#FFFFFF",
+		"settings.modifiedItemIndicator": "#BB800966",
+		"sideBar.background": "#181818",
+		"sideBar.border": "#2B2B2B",
+		"sideBar.foreground": "#CCCCCC",
+		"sideBarSectionHeader.background": "#181818",
+		"sideBarSectionHeader.border": "#2B2B2B",
+		"sideBarSectionHeader.foreground": "#CCCCCC",
+		"sideBarTitle.foreground": "#CCCCCC",
+		"statusBar.background": "#181818",
+		"statusBar.border": "#2B2B2B",
+		"statusBar.debuggingBackground": "#0078D4",
+		"statusBar.debuggingForeground": "#FFFFFF",
+		"statusBar.focusBorder": "#0078D4",
+		"statusBar.foreground": "#CCCCCC",
+		"statusBar.noFolderBackground": "#1F1F1F",
+		"statusBarItem.focusBorder": "#0078D4",
+		"statusBarItem.prominentBackground": "#6E768166",
+		"statusBarItem.remoteBackground": "#0078D4",
+		"statusBarItem.remoteForeground": "#FFFFFF",
+		"tab.activeBackground": "#1F1F1F",
+		"tab.activeBorder": "#1F1F1F",
+		"tab.activeBorderTop": "#0078D4",
+		"tab.activeForeground": "#FFFFFF",
+		"tab.selectedBorderTop": "#6caddf",
+		"tab.border": "#2B2B2B",
+		"tab.hoverBackground": "#1F1F1F",
+		"tab.inactiveBackground": "#181818",
+		"tab.inactiveForeground": "#9D9D9D",
+		"tab.unfocusedActiveBorder": "#1F1F1F",
+		"tab.unfocusedActiveBorderTop": "#2B2B2B",
+		"tab.unfocusedHoverBackground": "#1F1F1F",
+		"terminal.foreground": "#CCCCCC",
+		"terminal.tab.activeBorder": "#0078D4",
+		"textBlockQuote.background": "#2B2B2B",
+		"textBlockQuote.border": "#616161",
+		"textCodeBlock.background": "#2B2B2B",
+		"textLink.activeForeground": "#4daafc",
+		"textLink.foreground": "#4daafc",
+		"textPreformat.foreground": "#D0D0D0",
+		"textPreformat.background": "#3C3C3C",
+		"textSeparator.foreground": "#21262D",
+		"titleBar.activeBackground": "#181818",
+		"titleBar.activeForeground": "#CCCCCC",
+		"titleBar.border": "#2B2B2B",
+		"titleBar.inactiveBackground": "#1F1F1F",
+		"titleBar.inactiveForeground": "#9D9D9D",
+		"welcomePage.tileBackground": "#2B2B2B",
+		"welcomePage.progress.foreground": "#0078D4",
+		"widget.border": "#313131",
+	},
+	"tokenColors": [
+		{
+      "scope": [
+        "comment",
+        "comment.line.webgal"
+      ],
+      "settings": {
+        "foreground": "#757575"
+      }
+    },
+		{
+      "scope": [
+        "keyword.operator.webgal"
+      ],
+      "settings": {
+        "foreground": "#ff2c80",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "string.unquoted.utterance.webgal"
+      ],
+      "settings": {
+        "foreground": "#e6dd7e",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "meta.command.webgal",
+        "support.function.command.webgal"
+      ],
+      "settings": {
+        "foreground": "#5feaff",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "meta.character.webgal",
+        "entity.name.type.character.webgal"
+      ],
+      "settings": {
+        "foreground": "#ddff6f",
+				"fontStyle": "bold underline"
+      }
+    },
+    {
+      "scope": [
+        "variable.parameter.webgal",
+      ],
+      "settings": {
+        "foreground": "#ffb84a",
+      }
+    },
+    {
+      "scope": [
+        "variable.other.webgal",
+      ],
+      "settings": {
+        "foreground": "#6ef48f",
+      }
+    },
+		{
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"string meta.image.inline.markdown",
+				"variable.legacy.builtin.python"
+			],
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "strong",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "header",
+			"settings": {
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "constant.language",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"variable.other.enummember",
+				"keyword.operator.plus.exponent",
+				"keyword.operator.minus.exponent"
+			],
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "constant.regexp",
+			"settings": {
+				"foreground": "#646695"
+			}
+		},
+		{
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.tag.css",
+				"entity.name.tag.less"
+			],
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": [
+				"entity.other.attribute-name.class.css",
+				"source.css entity.other.attribute-name.class",
+				"entity.other.attribute-name.id.css",
+				"entity.other.attribute-name.parent-selector.css",
+				"entity.other.attribute-name.parent.less",
+				"source.css entity.other.attribute-name.pseudo-class",
+				"entity.other.attribute-name.pseudo-element.css",
+				"source.css.less entity.other.attribute-name.id",
+				"entity.other.attribute-name.scss"
+			],
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "invalid",
+			"settings": {
+				"foreground": "#f44747"
+			}
+		},
+		{
+			"scope": "markup.underline",
+			"settings": {
+				"fontStyle": "underline"
+			}
+		},
+		{
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "markup.strikethrough",
+			"settings": {
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"scope": "markup.inserted",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "markup.deleted",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "markup.changed",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "punctuation.definition.quote.begin.markdown",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "punctuation.definition.list.begin.markdown",
+			"settings": {
+				"foreground": "#6796e6"
+			}
+		},
+		{
+			"scope": "markup.inline.raw",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"name": "brackets of XML/HTML tags",
+			"scope": "punctuation.definition.tag",
+			"settings": {
+				"foreground": "#808080"
+			}
+		},
+		{
+			"scope": [
+				"meta.preprocessor",
+				"entity.name.function.preprocessor"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.string",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.numeric",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "meta.structure.dictionary.key.python",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "meta.diff.header",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "storage",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "storage.type",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"storage.modifier",
+				"keyword.operator.noexcept"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"string",
+				"meta.embedded.assembly"
+			],
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.tag",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.value",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"scope": [
+				"support.type.vendored.property-name",
+				"support.type.property-name",
+				"source.css variable",
+				"source.coffee.embedded"
+			],
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.control",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.new",
+				"keyword.operator.expression",
+				"keyword.operator.cast",
+				"keyword.operator.sizeof",
+				"keyword.operator.alignof",
+				"keyword.operator.typeid",
+				"keyword.operator.alignas",
+				"keyword.operator.instanceof",
+				"keyword.operator.logical.python",
+				"keyword.operator.wordlike"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.other.unit",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "support.function.git-rebase",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "constant.sha.git-rebase",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"name": "coloring of the Java import and package identifiers",
+			"scope": [
+				"storage.modifier.import.java",
+				"variable.language.wildcard.java",
+				"storage.modifier.package.java"
+			],
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"name": "this.self",
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"name": "Function declarations",
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"support.constant.handlebars",
+				"source.powershell variable.other.member",
+				"entity.name.operator.custom-literal" // See https://en.cppreference.com/w/cpp/language/user_literal
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"name": "Types declaration and references",
+			"scope": [
+				"support.class",
+				"support.type",
+				"entity.name.type",
+				"entity.name.namespace",
+				"entity.other.attribute",
+				"entity.name.scope-resolution",
+				"entity.name.class",
+				"storage.type.numeric.go",
+				"storage.type.byte.go",
+				"storage.type.boolean.go",
+				"storage.type.string.go",
+				"storage.type.uintptr.go",
+				"storage.type.error.go",
+				"storage.type.rune.go",
+				"storage.type.cs",
+				"storage.type.generic.cs",
+				"storage.type.modifier.cs",
+				"storage.type.variable.cs",
+				"storage.type.annotation.java",
+				"storage.type.generic.java",
+				"storage.type.java",
+				"storage.type.object.array.java",
+				"storage.type.primitive.array.java",
+				"storage.type.primitive.java",
+				"storage.type.token.java",
+				"storage.type.groovy",
+				"storage.type.annotation.groovy",
+				"storage.type.parameters.groovy",
+				"storage.type.generic.groovy",
+				"storage.type.object.array.groovy",
+				"storage.type.primitive.array.groovy",
+				"storage.type.primitive.groovy"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"name": "Types declaration and references, TS grammar specific",
+			"scope": [
+				"meta.type.cast.expr",
+				"meta.type.new.expr",
+				"support.constant.math",
+				"support.constant.dom",
+				"support.constant.json",
+				"entity.other.inherited-class",
+				"punctuation.separator.namespace.ruby"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"name": "Control flow / Special keywords",
+			"scope": [
+				"keyword.control",
+				"source.cpp keyword.operator.new",
+				"keyword.operator.delete",
+				"keyword.other.using",
+				"keyword.other.directive.using",
+				"keyword.other.operator",
+				"entity.name.operator"
+			],
+			"settings": {
+				"foreground": "#C586C0"
+			}
+		},
+		{
+			"name": "Variable and parameter name",
+			"scope": [
+				"variable",
+				"meta.definition.variable.name",
+				"support.variable",
+				"entity.name.variable",
+				"constant.other.placeholder", // placeholders in strings
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"name": "Constants and enums",
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
+			"settings": {
+				"foreground": "#4FC1FF",
+			}
+		},
+		{
+			"name": "Object keys, TS grammar specific",
+			"scope": [
+				"meta.object-literal.key"
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"name": "CSS property value",
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"name": "Regular expression groups",
+			"scope": [
+				"punctuation.definition.group.regexp",
+				"punctuation.definition.group.assertion.regexp",
+				"punctuation.definition.character-class.regexp",
+				"punctuation.character.set.begin.regexp",
+				"punctuation.character.set.end.regexp",
+				"keyword.operator.negation.regexp",
+				"support.other.parenthesis.regexp"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": [
+				"constant.character.character-class.regexp",
+				"constant.other.character-class.set.regexp",
+				"constant.other.character-class.regexp",
+				"constant.character.set.regexp"
+			],
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": [
+				"constant.character",
+				"constant.other.option"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "entity.name.label",
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		}
+	],
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"newOperator":"#C586C0",
+		"stringLiteral":"#ce9178",
+		"customLiteral": "#DCDCAA",
+		"numberLiteral": "#b5cea8",
+	}
+}

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -196,7 +196,7 @@ msgstr "Scale y"
 msgid "z-index"
 msgstr "z-index"
 
-#: src/pages/editor/Topbar/Topbar.tsx:129
+#: src/pages/editor/Topbar/Topbar.tsx:133
 msgid "一直显示功能区"
 msgstr "Always Show Toolbar"
 
@@ -277,9 +277,16 @@ msgstr "Setting effects or transformations for a figure or background image."
 msgid "主要样式"
 msgstr "Main Style"
 
-#: src/pages/editor/Topbar/Topbar.tsx:174
+#: src/pages/editor/Topbar/Topbar.tsx:202
 msgid "主页"
 msgstr "WebGAL Home"
+
+#: src/pages/dashboard/DashBoard.tsx:210
+#: src/pages/dashboard/DashBoard.tsx:211
+#: src/pages/editor/Topbar/Topbar.tsx:141
+#: src/pages/editor/Topbar/Topbar.tsx:152
+msgid "主题"
+msgstr "Theme"
 
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:78
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:87
@@ -486,7 +493,7 @@ msgid "最小高度"
 msgstr "Min Height"
 
 #: src/pages/dashboard/About.tsx:47
-#: src/pages/dashboard/DashBoard.tsx:157
+#: src/pages/dashboard/DashBoard.tsx:159
 msgid "最新版本"
 msgstr "Latest Version"
 
@@ -586,7 +593,7 @@ msgstr "Refresh game"
 msgid "前景"
 msgstr "Foreground"
 
-#: src/pages/editor/Topbar/Topbar.tsx:125
+#: src/pages/editor/Topbar/Topbar.tsx:129
 msgid "功能区显示"
 msgstr "Functional Area"
 
@@ -624,7 +631,7 @@ msgstr "Thickness"
 msgid "反射电影滤镜"
 msgstr "Reflection film filter"
 
-#: src/pages/dashboard/DashBoard.tsx:152
+#: src/pages/dashboard/DashBoard.tsx:154
 msgid "发现新版本"
 msgstr "New version detected"
 
@@ -696,6 +703,7 @@ msgid "图像"
 msgstr "Image"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:65
+#: src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx:35
 msgid "图形编辑器"
 msgstr "Graphical editor"
 
@@ -854,7 +862,7 @@ msgid "对话框标题"
 msgstr "Dialog title"
 
 #: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:62
-#: src/pages/editor/Topbar/Topbar.tsx:105
+#: src/pages/editor/Topbar/Topbar.tsx:109
 msgid "导出"
 msgstr "Export"
 
@@ -938,7 +946,7 @@ msgstr "Left side figure"
 msgid "左对齐"
 msgstr "Left align"
 
-#: src/pages/dashboard/DashBoard.tsx:108
+#: src/pages/dashboard/DashBoard.tsx:110
 msgid "已创建"
 msgstr "Created"
 
@@ -950,11 +958,11 @@ msgstr "File or folder already exists {0}, please enter another name"
 
 #: src/pages/editor/Topbar/tabs/Help/HelpTab.tsx:12
 #: src/pages/editor/Topbar/tabs/Help/HelpTab.tsx:15
-#: src/pages/editor/Topbar/Topbar.tsx:104
+#: src/pages/editor/Topbar/Topbar.tsx:108
 msgid "帮助"
 msgstr "Help"
 
-#: src/pages/editor/Topbar/Topbar.tsx:160
+#: src/pages/editor/Topbar/Topbar.tsx:188
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/index.tsx:114
 msgid "帮助文档"
 msgstr "Documents"
@@ -1000,7 +1008,7 @@ msgid "强度"
 msgstr "Intensity"
 
 #: src/pages/dashboard/About.tsx:41
-#: src/pages/dashboard/DashBoard.tsx:156
+#: src/pages/dashboard/DashBoard.tsx:158
 msgid "当前版本"
 msgstr "Current version"
 
@@ -1008,7 +1016,7 @@ msgstr "Current version"
 msgid "德语"
 msgstr "German"
 
-#: src/pages/dashboard/DashBoard.tsx:166
+#: src/pages/dashboard/DashBoard.tsx:168
 msgid "忽略此版本"
 msgstr "Ignore this version"
 
@@ -1447,7 +1455,7 @@ msgstr "Title background music"
 msgid "根文本长度 (rem)"
 msgstr "Root Font Size (rem)"
 
-#: src/pages/dashboard/DashBoard.tsx:214
+#: src/pages/dashboard/DashBoard.tsx:228
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
 msgid "模板"
 msgstr "Template"
@@ -1519,9 +1527,17 @@ msgstr "Comment"
 msgid "注释仅在编辑时可见，游戏中不会执行"
 msgstr "Comments are only visible when editing and will not be executed in the game"
 
+#: src/pages/editor/Topbar/Topbar.tsx:157
+msgid "浅色"
+msgstr "Light"
+
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:73
 msgid "淡入淡出"
 msgstr "Fade in and out"
+
+#: src/pages/editor/Topbar/Topbar.tsx:158
+msgid "深色"
+msgstr "Dark"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/AddProperty.tsx:51
 msgid "添加"
@@ -1563,7 +1579,7 @@ msgstr "Add Custom Property"
 
 #: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:275
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
-#: src/pages/editor/Topbar/Topbar.tsx:108
+#: src/pages/editor/Topbar/Topbar.tsx:112
 msgid "添加语句"
 msgstr "Add statement"
 
@@ -1577,7 +1593,7 @@ msgstr "Clear special effects of current stage"
 msgid "清除特效"
 msgstr "Clear effects"
 
-#: src/pages/dashboard/DashBoard.tsx:212
+#: src/pages/dashboard/DashBoard.tsx:226
 msgid "游戏"
 msgstr "Games"
 
@@ -1620,7 +1636,7 @@ msgstr "Game ID"
 msgid "游戏配置"
 msgstr "Game configuration"
 
-#: src/pages/editor/Topbar/Topbar.tsx:146
+#: src/pages/editor/Topbar/Topbar.tsx:174
 msgid "源代码"
 msgstr "Source code"
 
@@ -1685,7 +1701,7 @@ msgstr "Are you sure you want to delete the \"{templateName}\" template?"
 msgid "确认按钮文本"
 msgstr "Confirm button text"
 
-#: src/pages/editor/Topbar/Topbar.tsx:102
+#: src/pages/editor/Topbar/Topbar.tsx:106
 msgid "视图"
 msgstr "View"
 
@@ -1910,6 +1926,7 @@ msgid "背景颜色"
 msgstr "Background color"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:61
+#: src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx:28
 msgid "脚本编辑器"
 msgstr "Script editor"
 
@@ -1921,7 +1938,7 @@ msgstr "Auto"
 msgid "自动换行"
 msgstr "Auto wrap"
 
-#: src/pages/editor/Topbar/Topbar.tsx:130
+#: src/pages/editor/Topbar/Topbar.tsx:134
 msgid "自动隐藏功能区"
 msgstr "Auto-hide toolbar"
 
@@ -1960,7 +1977,7 @@ msgid "英语"
 msgstr "English"
 
 #: src/pages/dashboard/About.tsx:59
-#: src/pages/dashboard/DashBoard.tsx:162
+#: src/pages/dashboard/DashBoard.tsx:164
 msgid "获取最新版本"
 msgstr "Download Latest Version"
 
@@ -2047,7 +2064,7 @@ msgstr "Name of unlocked CG or BGM"
 msgid "解锁鉴赏类型"
 msgstr "Unlock appreciation type"
 
-#: src/pages/editor/Topbar/Topbar.tsx:103
+#: src/pages/editor/Topbar/Topbar.tsx:107
 msgid "设置"
 msgstr "Settings"
 
@@ -2087,8 +2104,8 @@ msgstr "This command is not recognized, please open script editing mode to edit 
 msgid "该文件类型不支持预览"
 msgstr "This file type does not support preview"
 
-#: src/pages/dashboard/DashBoard.tsx:195
-#: src/pages/dashboard/DashBoard.tsx:196
+#: src/pages/dashboard/DashBoard.tsx:197
+#: src/pages/dashboard/DashBoard.tsx:198
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:65
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:71
 msgid "语言"
@@ -2346,7 +2363,7 @@ msgstr "Opacity (0-1)"
 msgid "通过选项进入不同的场景"
 msgstr "Enter different scenes through options"
 
-#: src/pages/editor/Topbar/Topbar.tsx:101
+#: src/pages/editor/Topbar/Topbar.tsx:105
 msgid "配置"
 msgstr "Configuration"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -199,7 +199,7 @@ msgstr "Y軸スケール"
 msgid "z-index"
 msgstr "z-index"
 
-#: src/pages/editor/Topbar/Topbar.tsx:129
+#: src/pages/editor/Topbar/Topbar.tsx:133
 msgid "一直显示功能区"
 msgstr "常にツールバーを表示"
 
@@ -280,9 +280,16 @@ msgstr "人物や背景画像にエフェクトや変形を設定する。"
 msgid "主要样式"
 msgstr "メインスタイル"
 
-#: src/pages/editor/Topbar/Topbar.tsx:174
+#: src/pages/editor/Topbar/Topbar.tsx:202
 msgid "主页"
 msgstr "WebGALホーム"
+
+#: src/pages/dashboard/DashBoard.tsx:210
+#: src/pages/dashboard/DashBoard.tsx:211
+#: src/pages/editor/Topbar/Topbar.tsx:141
+#: src/pages/editor/Topbar/Topbar.tsx:152
+msgid "主题"
+msgstr "テーマ"
 
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:78
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:87
@@ -489,7 +496,7 @@ msgid "最小高度"
 msgstr "最小高さ"
 
 #: src/pages/dashboard/About.tsx:47
-#: src/pages/dashboard/DashBoard.tsx:157
+#: src/pages/dashboard/DashBoard.tsx:159
 msgid "最新版本"
 msgstr "最新バージョン"
 
@@ -589,7 +596,7 @@ msgstr "ゲームをリフレッシュ"
 msgid "前景"
 msgstr "Foreground"
 
-#: src/pages/editor/Topbar/Topbar.tsx:125
+#: src/pages/editor/Topbar/Topbar.tsx:129
 msgid "功能区显示"
 msgstr "機能区の表示"
 
@@ -627,7 +634,7 @@ msgstr "厚さ"
 msgid "反射电影滤镜"
 msgstr "反射映画"
 
-#: src/pages/dashboard/DashBoard.tsx:152
+#: src/pages/dashboard/DashBoard.tsx:154
 msgid "发现新版本"
 msgstr "新しいバージョンが検出されました"
 
@@ -699,6 +706,7 @@ msgid "图像"
 msgstr "画像"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:65
+#: src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx:35
 msgid "图形编辑器"
 msgstr "グラフィックエディタ"
 
@@ -857,7 +865,7 @@ msgid "对话框标题"
 msgstr "ダイアログタイトル"
 
 #: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:62
-#: src/pages/editor/Topbar/Topbar.tsx:105
+#: src/pages/editor/Topbar/Topbar.tsx:109
 msgid "导出"
 msgstr "エクスポート"
 
@@ -941,7 +949,7 @@ msgstr "左の立ち絵"
 msgid "左对齐"
 msgstr "左揃え"
 
-#: src/pages/dashboard/DashBoard.tsx:108
+#: src/pages/dashboard/DashBoard.tsx:110
 msgid "已创建"
 msgstr "作成済み"
 
@@ -953,11 +961,11 @@ msgstr "ファイルまたはフォルダは既に存在します {0}"
 
 #: src/pages/editor/Topbar/tabs/Help/HelpTab.tsx:12
 #: src/pages/editor/Topbar/tabs/Help/HelpTab.tsx:15
-#: src/pages/editor/Topbar/Topbar.tsx:104
+#: src/pages/editor/Topbar/Topbar.tsx:108
 msgid "帮助"
 msgstr "ヘルプ"
 
-#: src/pages/editor/Topbar/Topbar.tsx:160
+#: src/pages/editor/Topbar/Topbar.tsx:188
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/index.tsx:114
 msgid "帮助文档"
 msgstr "ヘルプドキュメント"
@@ -1003,7 +1011,7 @@ msgid "强度"
 msgstr "強度"
 
 #: src/pages/dashboard/About.tsx:41
-#: src/pages/dashboard/DashBoard.tsx:156
+#: src/pages/dashboard/DashBoard.tsx:158
 msgid "当前版本"
 msgstr "現在のバージョン"
 
@@ -1011,7 +1019,7 @@ msgstr "現在のバージョン"
 msgid "德语"
 msgstr "ドイツ語"
 
-#: src/pages/dashboard/DashBoard.tsx:166
+#: src/pages/dashboard/DashBoard.tsx:168
 msgid "忽略此版本"
 msgstr "このバージョンを無視する"
 
@@ -1446,7 +1454,7 @@ msgstr "タイトルのBGM"
 msgid "根文本长度 (rem)"
 msgstr "ルートテキストの長さ (rem)"
 
-#: src/pages/dashboard/DashBoard.tsx:214
+#: src/pages/dashboard/DashBoard.tsx:228
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
 msgid "模板"
 msgstr "テンプレート"
@@ -1518,9 +1526,17 @@ msgstr "コメント"
 msgid "注释仅在编辑时可见，游戏中不会执行"
 msgstr "コメントは編集時のみ表示され、ゲームプレイ時には非表示"
 
+#: src/pages/editor/Topbar/Topbar.tsx:157
+msgid "浅色"
+msgstr "ライト"
+
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:73
 msgid "淡入淡出"
 msgstr "フェードインとアウト"
+
+#: src/pages/editor/Topbar/Topbar.tsx:158
+msgid "深色"
+msgstr "ダーク"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/AddProperty.tsx:51
 msgid "添加"
@@ -1562,7 +1578,7 @@ msgstr "カスタム属性を追加"
 
 #: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:275
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
-#: src/pages/editor/Topbar/Topbar.tsx:108
+#: src/pages/editor/Topbar/Topbar.tsx:112
 msgid "添加语句"
 msgstr "ステートメントを追加"
 
@@ -1576,7 +1592,7 @@ msgstr "現在のステージの特殊効果をクリア"
 msgid "清除特效"
 msgstr "特殊効果をクリア"
 
-#: src/pages/dashboard/DashBoard.tsx:212
+#: src/pages/dashboard/DashBoard.tsx:226
 msgid "游戏"
 msgstr "ゲーム"
 
@@ -1619,7 +1635,7 @@ msgstr "ゲームID"
 msgid "游戏配置"
 msgstr "ゲーム構成"
 
-#: src/pages/editor/Topbar/Topbar.tsx:146
+#: src/pages/editor/Topbar/Topbar.tsx:174
 msgid "源代码"
 msgstr "ソースコード"
 
@@ -1684,7 +1700,7 @@ msgstr "テンプレート\"{templateName}\"を削除してもよろしいです
 msgid "确认按钮文本"
 msgstr "確認ボタンのテキスト"
 
-#: src/pages/editor/Topbar/Topbar.tsx:102
+#: src/pages/editor/Topbar/Topbar.tsx:106
 msgid "视图"
 msgstr "ビュー"
 
@@ -1909,6 +1925,7 @@ msgid "背景颜色"
 msgstr "背景色"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:61
+#: src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx:28
 msgid "脚本编辑器"
 msgstr "スクリプトエディタ"
 
@@ -1920,7 +1937,7 @@ msgstr "自動"
 msgid "自动换行"
 msgstr "自動折り返し"
 
-#: src/pages/editor/Topbar/Topbar.tsx:130
+#: src/pages/editor/Topbar/Topbar.tsx:134
 msgid "自动隐藏功能区"
 msgstr "ツールバーを自動的に隠す"
 
@@ -1959,7 +1976,7 @@ msgid "英语"
 msgstr "英語"
 
 #: src/pages/dashboard/About.tsx:59
-#: src/pages/dashboard/DashBoard.tsx:162
+#: src/pages/dashboard/DashBoard.tsx:164
 msgid "获取最新版本"
 msgstr "最新バージョンをダウンロード"
 
@@ -2046,7 +2063,7 @@ msgstr "CG/BGMの名前"
 msgid "解锁鉴赏类型"
 msgstr "タイプ"
 
-#: src/pages/editor/Topbar/Topbar.tsx:103
+#: src/pages/editor/Topbar/Topbar.tsx:107
 msgid "设置"
 msgstr "設定"
 
@@ -2086,8 +2103,8 @@ msgstr "このコマンドは認識されません、スクリプト編集モー
 msgid "该文件类型不支持预览"
 msgstr "このファイルタイプはプレビューをサポートしていません"
 
-#: src/pages/dashboard/DashBoard.tsx:195
-#: src/pages/dashboard/DashBoard.tsx:196
+#: src/pages/dashboard/DashBoard.tsx:197
+#: src/pages/dashboard/DashBoard.tsx:198
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:65
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:71
 msgid "语言"
@@ -2345,7 +2362,7 @@ msgstr "透明度（０－１）"
 msgid "通过选项进入不同的场景"
 msgstr "選択肢からシーンに切り替えることが可能です"
 
-#: src/pages/editor/Topbar/Topbar.tsx:101
+#: src/pages/editor/Topbar/Topbar.tsx:105
 msgid "配置"
 msgstr "設定"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -198,7 +198,7 @@ msgstr "Y轴缩放"
 msgid "z-index"
 msgstr "z-index"
 
-#: src/pages/editor/Topbar/Topbar.tsx:129
+#: src/pages/editor/Topbar/Topbar.tsx:133
 msgid "一直显示功能区"
 msgstr "一直显示功能区"
 
@@ -279,9 +279,16 @@ msgstr "为立绘或背景图片设置效果或变换"
 msgid "主要样式"
 msgstr "主要样式"
 
-#: src/pages/editor/Topbar/Topbar.tsx:174
+#: src/pages/editor/Topbar/Topbar.tsx:202
 msgid "主页"
 msgstr "主页"
+
+#: src/pages/dashboard/DashBoard.tsx:210
+#: src/pages/dashboard/DashBoard.tsx:211
+#: src/pages/editor/Topbar/Topbar.tsx:141
+#: src/pages/editor/Topbar/Topbar.tsx:152
+msgid "主题"
+msgstr "主题"
 
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:78
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:87
@@ -488,7 +495,7 @@ msgid "最小高度"
 msgstr "最小高度"
 
 #: src/pages/dashboard/About.tsx:47
-#: src/pages/dashboard/DashBoard.tsx:157
+#: src/pages/dashboard/DashBoard.tsx:159
 msgid "最新版本"
 msgstr "最新版本"
 
@@ -588,7 +595,7 @@ msgstr "刷新游戏"
 msgid "前景"
 msgstr "前景"
 
-#: src/pages/editor/Topbar/Topbar.tsx:125
+#: src/pages/editor/Topbar/Topbar.tsx:129
 msgid "功能区显示"
 msgstr "功能区显示"
 
@@ -626,7 +633,7 @@ msgstr "厚度"
 msgid "反射电影滤镜"
 msgstr "反射电影滤镜"
 
-#: src/pages/dashboard/DashBoard.tsx:152
+#: src/pages/dashboard/DashBoard.tsx:154
 msgid "发现新版本"
 msgstr "发现新版本"
 
@@ -698,6 +705,7 @@ msgid "图像"
 msgstr "图像"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:65
+#: src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx:35
 msgid "图形编辑器"
 msgstr "图形编辑器"
 
@@ -856,7 +864,7 @@ msgid "对话框标题"
 msgstr "对话框标题"
 
 #: src/pages/editor/Topbar/tabs/Export/ExportTab.tsx:62
-#: src/pages/editor/Topbar/Topbar.tsx:105
+#: src/pages/editor/Topbar/Topbar.tsx:109
 msgid "导出"
 msgstr "导出"
 
@@ -940,7 +948,7 @@ msgstr "左侧立绘"
 msgid "左对齐"
 msgstr "左对齐"
 
-#: src/pages/dashboard/DashBoard.tsx:108
+#: src/pages/dashboard/DashBoard.tsx:110
 msgid "已创建"
 msgstr "已创建"
 
@@ -952,11 +960,11 @@ msgstr "已存在文件或文件夹 {0}，请输入其他名称"
 
 #: src/pages/editor/Topbar/tabs/Help/HelpTab.tsx:12
 #: src/pages/editor/Topbar/tabs/Help/HelpTab.tsx:15
-#: src/pages/editor/Topbar/Topbar.tsx:104
+#: src/pages/editor/Topbar/Topbar.tsx:108
 msgid "帮助"
 msgstr "帮助"
 
-#: src/pages/editor/Topbar/Topbar.tsx:160
+#: src/pages/editor/Topbar/Topbar.tsx:188
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/index.tsx:114
 msgid "帮助文档"
 msgstr "帮助文档"
@@ -1002,7 +1010,7 @@ msgid "强度"
 msgstr "强度"
 
 #: src/pages/dashboard/About.tsx:41
-#: src/pages/dashboard/DashBoard.tsx:156
+#: src/pages/dashboard/DashBoard.tsx:158
 msgid "当前版本"
 msgstr "当前版本"
 
@@ -1010,7 +1018,7 @@ msgstr "当前版本"
 msgid "德语"
 msgstr "德语"
 
-#: src/pages/dashboard/DashBoard.tsx:166
+#: src/pages/dashboard/DashBoard.tsx:168
 msgid "忽略此版本"
 msgstr "忽略此版本"
 
@@ -1445,7 +1453,7 @@ msgstr "标题背景音乐"
 msgid "根文本长度 (rem)"
 msgstr "根文本长度 (rem)"
 
-#: src/pages/dashboard/DashBoard.tsx:214
+#: src/pages/dashboard/DashBoard.tsx:228
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
 msgid "模板"
 msgstr "模板"
@@ -1517,9 +1525,17 @@ msgstr "注释"
 msgid "注释仅在编辑时可见，游戏中不会执行"
 msgstr "注释仅在编辑时可见，游戏中不会执行"
 
+#: src/pages/editor/Topbar/Topbar.tsx:157
+msgid "浅色"
+msgstr "浅色"
+
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx:73
 msgid "淡入淡出"
 msgstr "淡入淡出"
+
+#: src/pages/editor/Topbar/Topbar.tsx:158
+msgid "深色"
+msgstr "深色"
 
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/AddProperty.tsx:51
 msgid "添加"
@@ -1561,7 +1577,7 @@ msgstr "添加自定义属性"
 
 #: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:275
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
-#: src/pages/editor/Topbar/Topbar.tsx:108
+#: src/pages/editor/Topbar/Topbar.tsx:112
 msgid "添加语句"
 msgstr "添加语句"
 
@@ -1575,7 +1591,7 @@ msgstr "清除当前舞台的特殊效果"
 msgid "清除特效"
 msgstr "清除特效"
 
-#: src/pages/dashboard/DashBoard.tsx:212
+#: src/pages/dashboard/DashBoard.tsx:226
 msgid "游戏"
 msgstr "游戏"
 
@@ -1618,7 +1634,7 @@ msgstr "游戏识别码"
 msgid "游戏配置"
 msgstr "游戏配置"
 
-#: src/pages/editor/Topbar/Topbar.tsx:146
+#: src/pages/editor/Topbar/Topbar.tsx:174
 msgid "源代码"
 msgstr "源代码"
 
@@ -1683,7 +1699,7 @@ msgstr "确定要删除 \"{templateName}\" 模板吗？"
 msgid "确认按钮文本"
 msgstr "确认按钮文本"
 
-#: src/pages/editor/Topbar/Topbar.tsx:102
+#: src/pages/editor/Topbar/Topbar.tsx:106
 msgid "视图"
 msgstr "视图"
 
@@ -1908,6 +1924,7 @@ msgid "背景颜色"
 msgstr "背景颜色"
 
 #: src/pages/editor/MainArea/EditorToolbar.tsx:61
+#: src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx:28
 msgid "脚本编辑器"
 msgstr "脚本编辑器"
 
@@ -1919,7 +1936,7 @@ msgstr "自动"
 msgid "自动换行"
 msgstr "自动换行"
 
-#: src/pages/editor/Topbar/Topbar.tsx:130
+#: src/pages/editor/Topbar/Topbar.tsx:134
 msgid "自动隐藏功能区"
 msgstr "自动隐藏功能区"
 
@@ -1958,7 +1975,7 @@ msgid "英语"
 msgstr "英语"
 
 #: src/pages/dashboard/About.tsx:59
-#: src/pages/dashboard/DashBoard.tsx:162
+#: src/pages/dashboard/DashBoard.tsx:164
 msgid "获取最新版本"
 msgstr "获取最新版本"
 
@@ -2045,7 +2062,7 @@ msgstr "解锁的 CG 或 BGM 名称"
 msgid "解锁鉴赏类型"
 msgstr "解锁鉴赏类型"
 
-#: src/pages/editor/Topbar/Topbar.tsx:103
+#: src/pages/editor/Topbar/Topbar.tsx:107
 msgid "设置"
 msgstr "设置"
 
@@ -2085,8 +2102,8 @@ msgstr "该指令没有被识别，请打开脚本编辑模式以手动编辑"
 msgid "该文件类型不支持预览"
 msgstr "该文件类型不支持预览"
 
-#: src/pages/dashboard/DashBoard.tsx:195
-#: src/pages/dashboard/DashBoard.tsx:196
+#: src/pages/dashboard/DashBoard.tsx:197
+#: src/pages/dashboard/DashBoard.tsx:198
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:65
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:71
 msgid "语言"
@@ -2344,7 +2361,7 @@ msgstr "透明度（0-1）"
 msgid "通过选项进入不同的场景"
 msgstr "通过选项进入不同的场景"
 
-#: src/pages/editor/Topbar/Topbar.tsx:101
+#: src/pages/editor/Topbar/Topbar.tsx:105
 msgid "配置"
 msgstr "配置"
 

--- a/packages/origine2/src/main.tsx
+++ b/packages/origine2/src/main.tsx
@@ -19,6 +19,8 @@ import {I18nProvider} from "@lingui/react";
 import {messages as enMessages} from "./locales/en";
 import {messages as zhCnMessages} from "./locales/zhCn";
 import {messages as jaMessages} from "./locales/ja";
+import useEditorStore from "./store/useEditorStore";
+import { useEffect } from "react";
 
 i18n.load({
   en: enMessages,
@@ -60,17 +62,31 @@ const darkTheme: Theme = {
 
 darkTheme.colorBrandForeground1 = terre[110];
 darkTheme.colorBrandForeground2 = terre[120];
-
 initializeIcons();
 
 i18n.activate('zhCn');
-// 不用 StrictMode，因为会和 react-butiful-dnd 冲突
+
+function Main() {
+  const isDarkMode = useEditorStore.use.isDarkMode();
+  useEffect(() => {
+    if (isDarkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [isDarkMode]);
+  return (
+    <FluentProvider theme={isDarkMode ? darkTheme : lightTheme} style={{width: '100%', height: '100%'}}>
+      <I18nProvider i18n={i18n}>
+        <App/>
+      </I18nProvider>
+    </FluentProvider>
+  );
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
+  // 不用 StrictMode，因为会和 react-butiful-dnd 冲突
   // <React.StrictMode>
-  <FluentProvider theme={lightTheme} style={{width: '100%', height: '100%'}}>
-    <I18nProvider i18n={i18n}>
-      <App/>
-    </I18nProvider>
-  </FluentProvider>
+  <Main />
   // </React.StrictMode>
 );

--- a/packages/origine2/src/pages/dashboard/DashBoard.tsx
+++ b/packages/origine2/src/pages/dashboard/DashBoard.tsx
@@ -51,6 +51,7 @@ import {t} from "@lingui/macro";
 import { useRelease } from "@/hooks/useRelease";
 import { __INFO } from "@/config/info";
 import {CreateGameDto, CreateTemplateDto} from "@/api/Api";
+import { Platte } from "@icon-park/react";
 
 export interface DateTimeFormatOptions {
   year: 'numeric' | '2-digit';
@@ -82,6 +83,7 @@ export default function DashBoard() {
 
   const subPage = useEditorStore.use.subPage();
   const updateLanguage = useEditorStore.use.updateLanguage();
+  const updateIsDarkMode = useEditorStore.use.updateIsDarkMode();
 
   const messageRef = useRef<TestRefRef>(null);
 
@@ -200,6 +202,18 @@ export default function DashBoard() {
                 <MenuItem onClick={() => updateLanguage('zhCn')}>简体中文</MenuItem>
                 <MenuItem onClick={() => updateLanguage('en')}>English</MenuItem>
                 <MenuItem onClick={() => updateLanguage('ja')}>日本語</MenuItem>
+              </MenuList>
+            </MenuPopover>
+          </Menu>
+          <Menu>
+            <MenuTrigger>
+              <ToolbarButton aria-label={t`主题`}
+                icon={<Platte/>}>{t`主题`}</ToolbarButton>
+            </MenuTrigger>
+            <MenuPopover>
+              <MenuList>
+                <MenuItem onClick={() => updateIsDarkMode(false)}>{t`浅色`}</MenuItem>
+                <MenuItem onClick={() => updateIsDarkMode(true)}>{t`深色`}</MenuItem>
               </MenuList>
             </MenuPopover>
           </Menu>

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -246,7 +246,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
                               <div className={styles.optionButton}
                                 onClick={() => deleteOneSentence(i)}>
                                 <DeleteFive strokeWidth={3} style={{padding: "2px 4px 0 0"}} theme="outline" size="14"
-                                  fill="#333"/>
+                                  fill="var(--text)"/>
                                 <div>
                                   {t`删除本句`}
                                 </div>
@@ -254,7 +254,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
                               <div className={styles.optionButton}
                                 onClick={() => syncToIndex(i)}>
                                 <Play strokeWidth={3} style={{padding: "2px 4px 0 0"}} theme="outline" size="14"
-                                  fill="#333"/>
+                                  fill="var(--text)"/>
                                 <div>
                                   {t`执行到此句`}
                                 </div>

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/sentenceEditor.module.scss
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/sentenceEditor.module.scss
@@ -22,6 +22,7 @@
   box-shadow: none;
   appearance: none;
   outline: none;
+  color: var(--text);
   background: var(--bg-input);
   border: var(--border-md);
   padding: 6px 6px 6px 6px;
@@ -31,6 +32,7 @@
 }
 
 .sayArea {
+  color: var(--text);
   background: var(--bg-input);
   border: var(--border-md);
   width: 75%;

--- a/packages/origine2/src/pages/editor/GraphicalEditor/components/optionCategory.module.scss
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/components/optionCategory.module.scss
@@ -1,21 +1,20 @@
 .item {
   display: flex;
   flex-flow: column;
-  background-color: rgb(255, 255, 255);
   margin-top: 5px;
   margin-bottom: 5px;
 }
 
 .title {
   text-align: left;
-  color: rgb(99, 99, 99);
+  color: var(--text);
   font-weight: bold;
   font-size: 110%;
   padding-left: 10px;
   padding-right: 10px;
   padding-top: 5px;
   padding-bottom: 5px;
-  background-color: rgb(245, 245, 245);
+  background-color: var(--black-5pct);
 }
 
 .contentRow {

--- a/packages/origine2/src/pages/editor/GraphicalEditor/components/searchableCascader.module.scss
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/components/searchableCascader.module.scss
@@ -83,11 +83,11 @@
 
 .cascadeOptionActive {
   transition: all 0.2s ease-in-out;
-  background-color: skyblue;
+  background-color: var(--primary-10pct);
 }
 
 .cascadeOptionActive.cascadeOption:hover {
-  background-color: skyblue;
+  background-color: var(--primary-10pct);
 }
 
 .cascadeOption:not(:last-child) {
@@ -124,7 +124,7 @@
 }
 
 .highlight {
-  background: skyblue;
+  background: var(--primary);
   color: inherit;
   font-weight: bold;
   padding: 0 2px;

--- a/packages/origine2/src/pages/editor/MainArea/EditorToolbar.tsx
+++ b/packages/origine2/src/pages/editor/MainArea/EditorToolbar.tsx
@@ -48,20 +48,20 @@ export default function EditorToolbar() {
 
   return <div className={s.toolbar}>
     <div className={s.toolbar_button+ ' ' + (isShowDebugger  ? s.toolbar_button_active : '')} onClick={()=>switchDebugger()}>
-      <Terminal theme="outline" size="20" fill={isShowDebugger ? '#005CAF' : "#333"} strokeWidth={3}/>
+      <Terminal theme="outline" size="20" fill={isShowDebugger ? 'var(--primary)' : "var(--text)"} strokeWidth={3}/>
       DEBUGGER
     </div>
     <div className={s.toolbar_button}>
-      <DataSheet theme="outline" size="20" fill="#333" strokeWidth={3}/>
+      <DataSheet theme="outline" size="20" fill="var(--text)" strokeWidth={3}/>
       {lineNumString} {t`行脚本`}, {textNumString} {t`个字`}
     </div>
     <div onClick={handleSetCodeMode} className={s.toolbar_button + ' ' + (isCodeMode ? s.toolbar_button_active : '')}
       style={{marginLeft: 'auto'}}>
-      <FileCodeOne theme="outline" size="20" fill={isCodeMode ? '#005CAF' : "#333"} strokeWidth={3}/>
+      <FileCodeOne theme="outline" size="20" fill={isCodeMode ? 'var(--primary)' : "var(--text)"} strokeWidth={3}/>
       {t`脚本编辑器`}
     </div>
     <div onClick={handleSetGraphMode} className={s.toolbar_button + ' ' + (!isCodeMode ? s.toolbar_button_active : '')}>
-      <ListView theme="outline" size="20" fill={isCodeMode ? "#333" : '#005CAF'} strokeWidth={3}/>
+      <ListView theme="outline" size="20" fill={isCodeMode ? "var(--text)" : 'var(--primary)'} strokeWidth={3}/>
       {t`图形编辑器`}
     </div>
   </div>;

--- a/packages/origine2/src/pages/editor/MainArea/editorToolbar.module.scss
+++ b/packages/origine2/src/pages/editor/MainArea/editorToolbar.module.scss
@@ -1,11 +1,11 @@
 .toolbar {
-  border-top: 1px solid var(--divide, #D1D1D1);
+  border-top: var(--border-sm);
   display: flex;
   align-items: center;
   height: 28px;
   padding: 0 8px;
   gap: 8px;
-  background: rgba(245, 245, 245, 1);
+  background: var(--bg-card);
 }
 
 .toolbar_button {
@@ -14,7 +14,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  color: #333;
+  color: var(--text);
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
@@ -26,14 +26,14 @@
 }
 
 .toolbar_button:hover {
-  background: #E1E1E1;
+  background: var(--bg-button-hover);
 }
 
 .toolbar_button_active {
-  background: rgba(233, 238, 242, 1);
+  background: var(--bg-button-hover);
   color: var(--primary);
 }
 
 .active {
-  background: #c8c8c8;
+  background: var(--bg-button-hover);
 }

--- a/packages/origine2/src/pages/editor/Topbar/Topbar.tsx
+++ b/packages/origine2/src/pages/editor/Topbar/Topbar.tsx
@@ -36,6 +36,7 @@ import {IGameEditorSidebarTabs, IGameEditorTopbarTabs} from "@/types/gameEditor"
 import {redirect} from "@/hooks/useHashRoute";
 import {t} from "@lingui/macro";
 import BackDashboardButton from "@/pages/editor/Topbar/components/BackDashboardButton";
+import { Platte } from "@icon-park/react";
 
 const PaddingTopIcon = bundleIcon(PaddingTop24Filled, PaddingTop24Regular);
 const EyeOffIcon = bundleIcon(EyeOff24Filled, EyeOff24Regular);
@@ -45,6 +46,9 @@ export default function TopBar() {
 
   const isAutoHideToolbar = useEditorStore.use.isAutoHideToolbar();
   const updateIsAutoHideToolbar = useEditorStore.use.updateIisAutoHideToolbar();
+
+  const isDarkMode = useEditorStore.use.isDarkMode();
+  const updateIsDarkMode = useEditorStore.use.updateIsDarkMode();
 
   const isCodeMode = useGameEditorContext((state) => state.isCodeMode); // false 是脚本模式 true 是图形化模式
   const currentTopbarTab = useGameEditorContext((state) => state.currentTopbarTab);
@@ -131,8 +135,32 @@ export default function TopBar() {
           </MenuList>
         </MenuPopover>
       </Menu>
+      <Menu>
+        <MenuTrigger>
+          <ToolbarButton
+            aria-label={t`主题`}
+            icon={<Platte/>}
+            style={{
+              fontWeight: 'normal',
+              fontSize: '14px',
+              paddingLeft: '4px',
+              paddingRight: '4px',
+              minWidth: 0,
+              textWrap: 'nowrap'
+            }}
+          >
+            {t`主题`}
+          </ToolbarButton>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem onClick={() => updateIsDarkMode(false)}>{t`浅色`}</MenuItem>
+            <MenuItem onClick={() => updateIsDarkMode(true)}>{t`深色`}</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
       <ToolbarButton
-        icon={<img src={GithubIcon} height={20} width={20} alt="GitHub Repo"/>}
+        icon={<img src={GithubIcon} height={20} width={20} alt="GitHub Repo" style={isDarkMode ? { filter: 'brightness(0) invert(1)' } : {}} />}
         onClick={() => window.open("https://github.com/OpenWebGAL/WebGAL_Terre", "_blank")}
         style={{
           fontWeight: 'normal',

--- a/packages/origine2/src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx
+++ b/packages/origine2/src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx
@@ -264,7 +264,7 @@ function GameConfigEditor(props: IGameConfigEditor) {
     {!showEditBox.value && props.value}
     {!showEditBox.value &&
       <span className={styles.editButton} onClick={() => showEditBox.set(true)}>
-        <Write theme="outline" size="16" fill="#005CAF" strokeWidth={3}/>
+        <Write theme="outline" size="16" fill="var(--primary)" strokeWidth={3}/>
       </span>}
     {showEditBox.value &&
       <Input
@@ -314,7 +314,7 @@ function GameConfigEditorWithFileChoose(props: IGameConfigEditor & {
       basePath={[props.sourceBase]}
       button={
         <span className={styles.editButton}>
-          <Write theme="outline" size="16" fill="#005CAF" strokeWidth={3}/>
+          <Write theme="outline" size="16" fill="var(--primary)" strokeWidth={3}/>
         </span>
       }
       selectedFilePath={props.value}

--- a/packages/origine2/src/pages/editor/Topbar/tabs/topbarTabs.module.scss
+++ b/packages/origine2/src/pages/editor/Topbar/tabs/topbarTabs.module.scss
@@ -21,7 +21,7 @@
 }
 
 .sidebar_gameconfig_title {
-  color: #323130;
+  color: var(--text);
   text-align: center;
   font-size: 14px;
   font-style: normal;
@@ -57,7 +57,7 @@
 .divider {
   height: 90%;
   align-self: center;
-  border-right: 1px solid rgba(0, 0, 0, 0.2);
+  border-right: var(--border-sm);
   margin-left: 0.5em;
 }
 

--- a/packages/origine2/src/pages/templateEditor/TemplateEditor.tsx
+++ b/packages/origine2/src/pages/templateEditor/TemplateEditor.tsx
@@ -31,11 +31,11 @@ export const sendComponentPreviewMessage = (componentPath: string, componentClas
     ]);
   }
   else if (componentPath.includes(useComponentTreeTextbox().path)) {
-    const miniAvatar = !componentClass.toLowerCase().includes("miniavataroff") ? "miniavatar.png" : "";
-    WsUtil.runTempScene(`changeBg:bg.png -next;\nminiAvatar:${miniAvatar} -next;\n${useTemplateTempScene().textbox}`);
+    const miniAvatar = !componentClass.toLowerCase().includes("miniavataroff") ? "miniavatar.webp" : "";
+    WsUtil.runTempScene(`changeBg:bg.webp -next;\nminiAvatar:${miniAvatar} -next;\n${useTemplateTempScene().textbox}`);
   }
   else if (componentPath.includes(useComponentTreeChoose().path)) {
-    WsUtil.runTempScene(`changeBg:bg.png -next;\n${useTemplateTempScene().choose}`);
+    WsUtil.runTempScene(`changeBg:bg.webp -next;\n${useTemplateTempScene().choose}`);
   }
 };
 

--- a/packages/origine2/src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx
+++ b/packages/origine2/src/pages/templateEditor/TemplateEditorMainAria/TemplateEditorToolbar.tsx
@@ -2,6 +2,7 @@ import { useTemplateEditorContext } from '@/store/useTemplateEditorStore';
 import styles from './templateEditorToolbar.module.scss';
 import { CodeTextEditFilled, CodeTextEditRegular, SlideGridFilled, SlideGridRegular, bundleIcon } from '@fluentui/react-icons';
 import { FileCodeOne, ListView } from '@icon-park/react';
+import { t } from '@lingui/macro';
 
 export default function TemplateEditorToolbar() {
 
@@ -23,15 +24,15 @@ export default function TemplateEditorToolbar() {
             className={`${styles.toolbarButton} ${isCodeMode ? styles.toolbarButtonActive : ''}`}
             onClick={() => updateIsCodeMode(true)}
           >
-            <FileCodeOne theme="outline" size="20" fill={isCodeMode ? '#005CAF' : "#333"} strokeWidth={3} />
-          代码编辑器
+            <FileCodeOne theme="outline" size="20" fill={isCodeMode ? 'var(--primary)' : 'var(--text)'} strokeWidth={3} />
+          {t`脚本编辑器`}
           </div>
           <div
             className={`${styles.toolbarButton} ${!isCodeMode ? styles.toolbarButtonActive : ''}`}
             onClick={() => updateIsCodeMode(false)}
           >
-            <ListView theme="outline" size="20" fill={isCodeMode ? "#333" : '#005CAF'} strokeWidth={3} />
-          图形编辑器
+            <ListView theme="outline" size="20" fill={isCodeMode ? 'var(--text)' : 'var(--primary)'} strokeWidth={3} />
+          {t`图形编辑器`}
           </div>
         </>
         }

--- a/packages/origine2/src/pages/templateEditor/TextEditor/TextEditor.tsx
+++ b/packages/origine2/src/pages/templateEditor/TextEditor/TextEditor.tsx
@@ -3,6 +3,7 @@ import useSWR, { useSWRConfig } from 'swr';
 import axios from 'axios';
 import { api } from '@/api';
 import { WsUtil } from '@/utils/wsUtil';
+import useEditorStore from '@/store/useEditorStore';
 
 export default function TextEditor({ path }: { path: string }) {
   const { mutate } = useSWRConfig();
@@ -14,6 +15,8 @@ export default function TextEditor({ path }: { path: string }) {
   };
 
   const { data } = useSWR(path, fileFetcher);
+
+  const isDarkMode = useEditorStore.use.isDarkMode();
 
   const update = async (text: string) => {
     await api.assetsControllerEditTextFile({ textFile: text, path: path });
@@ -62,7 +65,8 @@ export default function TextEditor({ path }: { path: string }) {
 
     iframe.contentWindow?.postMessage({ type: 'setValue', value: data }, '*');
     iframe.contentWindow?.postMessage({ type: 'setLanguage', language: extName }, '*');
-  }, [data, editorReady, extName]);
+    iframe.contentWindow?.postMessage({ type: 'setTheme', theme: isDarkMode ? 'vs-dark' : 'vs' }, '*');
+  }, [data, editorReady, extName, isDarkMode]);
 
   return memoizedIframe;
 }

--- a/packages/origine2/src/store/useEditorStore.ts
+++ b/packages/origine2/src/store/useEditorStore.ts
@@ -30,6 +30,7 @@ const useEditorStoreBase = create<IEditorState & IEditorAction>()(
       ignoreVersion: '',
       isCascaderDelimitersCustomizable: false,
       cascaderDelimiters: ['/'],
+      isDarkMode: false,
       updatePage: (page) => set({page}),
       updateSubPage: (subPage) => {
         set({ subPage });
@@ -40,7 +41,7 @@ const useEditorStoreBase = create<IEditorState & IEditorAction>()(
       updateEditorFontFamily: (editorFontFamily) => {
         set({editorFontFamily});
         updateUserConfiguration(`{
-          "workbench.colorTheme": "WebGAL White",
+          "workbench.colorTheme": "${get().isDarkMode ? 'WebGAL Dark' : 'WebGAL White'}",
           "editor.semanticHighlighting.enabled": "configuredByTheme",
           "editor.fontFamily": "${get().editorFontFamily}",
           "editor.fontSize": ${get().editorFontSize},
@@ -49,7 +50,7 @@ const useEditorStoreBase = create<IEditorState & IEditorAction>()(
       updateEditorFontSize: (editorFontSize) => {
         set({editorFontSize});
         updateUserConfiguration(`{
-          "workbench.colorTheme": "WebGAL White",
+          "workbench.colorTheme": "${get().isDarkMode ? 'WebGAL Dark' : 'WebGAL White'}",
           "editor.semanticHighlighting.enabled": "configuredByTheme",
           "editor.fontFamily": "${get().editorFontFamily}",
           "editor.fontSize": ${get().editorFontSize},
@@ -65,7 +66,8 @@ const useEditorStoreBase = create<IEditorState & IEditorAction>()(
       updateIsUseFontOptimization: (isUseFontOptimization) => set({ isUseFontOptimization }),
       updateIgnoreVersion: (ignoreVersion) => set({ignoreVersion}),
       updateIsCascaderDelimitersCustomizable: (isCascaderDelimitersCustomizable) => set({isCascaderDelimitersCustomizable}) ,
-      updateCascaderDelimiters: (cascaderDelimiters) => set({cascaderDelimiters})
+      updateCascaderDelimiters: (cascaderDelimiters) => set({cascaderDelimiters}),
+      updateIsDarkMode: (isDarkMode) => set({ isDarkMode }),
     }),
     {
       name: 'editor-storage',

--- a/packages/origine2/src/types/editor.ts
+++ b/packages/origine2/src/types/editor.ts
@@ -20,6 +20,7 @@ export interface IEditorState {
   ignoreVersion: string, // 忽略版本
   isCascaderDelimitersCustomizable: boolean,
   cascaderDelimiters: string[],
+  isDarkMode: boolean,
 }
 
 export interface IEditorAction {
@@ -40,4 +41,5 @@ export interface IEditorAction {
   updateIgnoreVersion: (ignoreVersion: IEditorState['ignoreVersion']) => void,
   updateIsCascaderDelimitersCustomizable: (isCascaderDelimitersCustomizable: IEditorState['isCascaderDelimitersCustomizable']) => void,
   updateCascaderDelimiters: (cascadeDelimiters: IEditorState['cascaderDelimiters']) => void,
+  updateIsDarkMode: (isDarkMode: IEditorState['isDarkMode']) => void,
 }

--- a/packages/origine2/src/webgalscript/extension.ts
+++ b/packages/origine2/src/webgalscript/extension.ts
@@ -16,6 +16,12 @@ const manifest: IExtensionManifest = {
         path: '/white.json',
         uiTheme: 'vs',
       },
+      // @ts-ignore id type problem
+      {
+        label: 'WebGAL Black',
+        path: '/black.json',
+        uiTheme: 'vs',
+      },
     ],
     grammars: [
       {
@@ -31,4 +37,5 @@ const manifest: IExtensionManifest = {
 const { registerFileUrl } = registerExtension(manifest, ExtensionHostKind.LocalProcess);
 
 registerFileUrl('/white.json', new URL('../config/themes/monokai-light-vs.json', import.meta.url).href);
+registerFileUrl('/black.json', new URL('../config/themes/vscode-dark-modern.json', import.meta.url).href);
 registerFileUrl('/hl.json', new URL('../config/highlighting/hl.json', import.meta.url).href);

--- a/packages/origine2/src/webgalscript/lsp.ts
+++ b/packages/origine2/src/webgalscript/lsp.ts
@@ -46,12 +46,23 @@ export const runClient = async () => {
     },
   });
 
-  updateUserConfiguration(`{
-    "workbench.colorTheme": "WebGAL White",
-    "editor.semanticHighlighting.enabled": "configuredByTheme",
-    "editor.fontFamily": "${useEditorStore.getState().editorFontFamily}",
-    "editor.fontSize": ${useEditorStore.getState().editorFontSize},
-  }`);
+  const applyEditorConfig = () => {
+    const isDarkMode = useEditorStore.getState().isDarkMode;
+    updateUserConfiguration(`{
+      "workbench.colorTheme": "${isDarkMode ? "WebGAL Black" : "WebGAL White"}",
+      "editor.semanticHighlighting.enabled": "configuredByTheme",
+      "editor.fontFamily": "${useEditorStore.getState().editorFontFamily}",
+      "editor.fontSize": ${useEditorStore.getState().editorFontSize}
+    }`);
+  };
+
+  // 初始调用
+  applyEditorConfig();
+
+  // 监听 isDarkMode 变化
+  useEditorStore.subscribe((state) => {
+    applyEditorConfig();
+  });
 
   monaco.languages.register({
     id: 'webgal',


### PR DESCRIPTION
# 介绍
- 支持切换主题, 目前有 __浅色__ 和 __深色__ 两个选项, 微调了部分样式颜色
<img width="1026" height="601" alt="image" src="https://github.com/user-attachments/assets/c053a70d-a84f-4dd9-98a5-079113ccf501" />
<img width="1460" height="765" alt="image" src="https://github.com/user-attachments/assets/fdde6ea9-d849-49d6-8d5a-6fb450c3139c" />
<img width="1457" height="766" alt="image" src="https://github.com/user-attachments/assets/08a69b15-734b-47a4-9d0f-91b9d30ae2c9" />


- 修复模板编辑器的 png 资源为 webp
- 修复模板编辑器底部栏没有翻译的问题
- 修复语法高亮颜色实际上并未生效正确生效的问题