### PR TITLE
feat: command graphical add editing operations

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -572,7 +572,7 @@ msgstr "Delete"
 msgid "删除属性"
 msgstr "Delete Property"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:249
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:379
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:36
 msgid "删除本句"
 msgstr "Delete this sentence"
@@ -599,6 +599,10 @@ msgstr "Refresh game"
 #: src/components/IconCreator/IconCreator.tsx:655
 msgid "前景"
 msgstr "Foreground"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:129
+msgid "剪切"
+msgstr "Cut"
 
 #: src/pages/editor/Topbar/Topbar.tsx:127
 msgid "功能区显示"
@@ -653,6 +657,10 @@ msgstr "Cancel"
 msgid "取消固定"
 msgstr "Unpin"
 
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:119
+msgid "取消选择"
+msgstr "Unselect"
+
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:116
 msgid "变换"
 msgstr "Transform"
@@ -675,6 +683,16 @@ msgstr "Right side figure"
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGText.tsx:21
 msgid "右对齐"
 msgstr "Right Align"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:136
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:409
+msgid "向上粘贴"
+msgstr "Paste up"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:425
+msgid "向下粘贴"
+msgstr "Paste down"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:112
 msgid "启动、切换或停止背景音乐的播放"
@@ -774,6 +792,10 @@ msgstr "Scenes and branches"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeCallScene.tsx:27
 msgid "场景文件"
 msgstr "Scene file"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:124
+msgid "复制"
+msgstr "Copy"
 
 #: src/pages/templateEditor/TemplateEditorSidebar/ComponentTree/ComponentTree.tsx:41
 msgid "外层文本"
@@ -1054,7 +1076,7 @@ msgstr "Manually enter ID"
 msgid "打开效果编辑器"
 msgstr "Open effect editor"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:257
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:389
 msgid "执行到此句"
 msgstr "Execute to this sentence"
 
@@ -1421,7 +1443,7 @@ msgstr "Unrecognized"
 msgid "未识别的指令"
 msgstr "Unrecognized command"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:220
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:337
 msgid "本句前插入句子"
 msgstr "Insert sentence before this"
 
@@ -1597,7 +1619,7 @@ msgstr "Add new line"
 msgid "添加自定义属性"
 msgstr "Add Custom Property"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:273
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:450
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
 #: src/pages/editor/Topbar/Topbar.tsx:110
 msgid "添加语句"
@@ -1786,14 +1808,23 @@ msgstr "Figure file"
 msgid "简体中文"
 msgstr "Simplified Chinese"
 
-#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:90
-#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:103
-msgid "红色通道"
-msgstr "Red channel"
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:94
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:372
+#~ msgid "粘贴"
+#~ msgstr "Paste"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:208
 msgid "紧急回避"
 msgstr "Emergency Evasion"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+msgid "繁体中文"
+msgstr "Traditional Chinese"
+
+#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:90
+#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:103
+msgid "红色通道"
+msgstr "Red channel"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:121
 msgid "纹理"
@@ -1896,10 +1927,6 @@ msgstr "Edit game"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "Edit component"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
-msgid "繁体中文"
-msgstr "Traditional Chinese"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -572,7 +572,7 @@ msgstr "Delete"
 msgid "删除属性"
 msgstr "Delete Property"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:379
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:365
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:36
 msgid "删除本句"
 msgstr "Delete this sentence"
@@ -600,7 +600,7 @@ msgstr "Refresh game"
 msgid "前景"
 msgstr "Foreground"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:129
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:131
 msgid "剪切"
 msgstr "Cut"
 
@@ -657,7 +657,7 @@ msgstr "Cancel"
 msgid "取消固定"
 msgstr "Unpin"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:119
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:121
 msgid "取消选择"
 msgstr "Unselect"
 
@@ -684,13 +684,13 @@ msgstr "Right side figure"
 msgid "右对齐"
 msgstr "Right Align"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:136
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:409
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:414
 msgid "向上粘贴"
 msgstr "Paste up"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:141
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:425
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:143
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:430
 msgid "向下粘贴"
 msgstr "Paste down"
 
@@ -793,7 +793,7 @@ msgstr "Scenes and branches"
 msgid "场景文件"
 msgstr "Scene file"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:124
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:126
 msgid "复制"
 msgstr "Copy"
 
@@ -1076,7 +1076,7 @@ msgstr "Manually enter ID"
 msgid "打开效果编辑器"
 msgstr "Open effect editor"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:389
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:375
 msgid "执行到此句"
 msgstr "Execute to this sentence"
 
@@ -1443,7 +1443,7 @@ msgstr "Unrecognized"
 msgid "未识别的指令"
 msgstr "Unrecognized command"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:337
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:323
 msgid "本句前插入句子"
 msgstr "Insert sentence before this"
 
@@ -1619,7 +1619,7 @@ msgstr "Add new line"
 msgid "添加自定义属性"
 msgstr "Add Custom Property"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:450
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:455
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
 #: src/pages/editor/Topbar/Topbar.tsx:110
 msgid "添加语句"

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -575,7 +575,7 @@ msgstr "削除"
 msgid "删除属性"
 msgstr "属性を削除"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:249
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:379
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:36
 msgid "删除本句"
 msgstr "この文を削除"
@@ -602,6 +602,10 @@ msgstr "ゲームをリフレッシュ"
 #: src/components/IconCreator/IconCreator.tsx:655
 msgid "前景"
 msgstr "Foreground"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:129
+msgid "剪切"
+msgstr "切り抜きます"
 
 #: src/pages/editor/Topbar/Topbar.tsx:127
 msgid "功能区显示"
@@ -656,6 +660,10 @@ msgstr "キャンセル"
 msgid "取消固定"
 msgstr "ピン留めを解除"
 
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:119
+msgid "取消选择"
+msgstr "選択をキャンセルします"
+
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:116
 msgid "变换"
 msgstr "トランスフォーム"
@@ -678,6 +686,16 @@ msgstr "右の立ち絵"
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGText.tsx:21
 msgid "右对齐"
 msgstr "右揃え"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:136
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:409
+msgid "向上粘贴"
+msgstr "上に貼り付けます"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:425
+msgid "向下粘贴"
+msgstr "下に貼り付けます"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:112
 msgid "启动、切换或停止背景音乐的播放"
@@ -777,6 +795,10 @@ msgstr "シーンとブランチ"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeCallScene.tsx:27
 msgid "场景文件"
 msgstr "シーンファイル"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:124
+msgid "复制"
+msgstr "複製します"
 
 #: src/pages/templateEditor/TemplateEditorSidebar/ComponentTree/ComponentTree.tsx:41
 msgid "外层文本"
@@ -1057,7 +1079,7 @@ msgstr "IDを手動で設定"
 msgid "打开效果编辑器"
 msgstr "エフェクトエディタを開く"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:257
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:389
 msgid "执行到此句"
 msgstr "この文まで実行"
 
@@ -1420,7 +1442,7 @@ msgstr "認識されないコマンド"
 msgid "未识别的指令"
 msgstr "認識されないコマンド"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:220
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:337
 msgid "本句前插入句子"
 msgstr "選択した文の前に追加"
 
@@ -1596,7 +1618,7 @@ msgstr "新しい行を追加"
 msgid "添加自定义属性"
 msgstr "カスタム属性を追加"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:273
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:450
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
 #: src/pages/editor/Topbar/Topbar.tsx:110
 msgid "添加语句"
@@ -1785,14 +1807,23 @@ msgstr "立ち絵ファイル"
 msgid "简体中文"
 msgstr "簡体字中国語"
 
-#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:90
-#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:103
-msgid "红色通道"
-msgstr "赤いチャネル"
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:94
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:372
+#~ msgid "粘贴"
+#~ msgstr "貼り付けます"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:208
 msgid "紧急回避"
 msgstr "緊急回避"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+msgid "繁体中文"
+msgstr "繁体字中国語"
+
+#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:90
+#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:103
+msgid "红色通道"
+msgstr "赤いチャネル"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:121
 msgid "纹理"
@@ -1895,10 +1926,6 @@ msgstr "ゲームの編集"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "コンポーネントの編集"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
-msgid "繁体中文"
-msgstr "繁体字中国語"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -575,7 +575,7 @@ msgstr "削除"
 msgid "删除属性"
 msgstr "属性を削除"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:379
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:365
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:36
 msgid "删除本句"
 msgstr "この文を削除"
@@ -603,7 +603,7 @@ msgstr "ゲームをリフレッシュ"
 msgid "前景"
 msgstr "Foreground"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:129
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:131
 msgid "剪切"
 msgstr "切り抜きます"
 
@@ -660,7 +660,7 @@ msgstr "キャンセル"
 msgid "取消固定"
 msgstr "ピン留めを解除"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:119
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:121
 msgid "取消选择"
 msgstr "選択をキャンセルします"
 
@@ -687,13 +687,13 @@ msgstr "右の立ち絵"
 msgid "右对齐"
 msgstr "右揃え"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:136
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:409
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:414
 msgid "向上粘贴"
 msgstr "上に貼り付けます"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:141
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:425
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:143
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:430
 msgid "向下粘贴"
 msgstr "下に貼り付けます"
 
@@ -796,7 +796,7 @@ msgstr "シーンとブランチ"
 msgid "场景文件"
 msgstr "シーンファイル"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:124
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:126
 msgid "复制"
 msgstr "複製します"
 
@@ -1079,7 +1079,7 @@ msgstr "IDを手動で設定"
 msgid "打开效果编辑器"
 msgstr "エフェクトエディタを開く"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:389
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:375
 msgid "执行到此句"
 msgstr "この文まで実行"
 
@@ -1442,7 +1442,7 @@ msgstr "認識されないコマンド"
 msgid "未识别的指令"
 msgstr "認識されないコマンド"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:337
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:323
 msgid "本句前插入句子"
 msgstr "選択した文の前に追加"
 
@@ -1618,7 +1618,7 @@ msgstr "新しい行を追加"
 msgid "添加自定义属性"
 msgstr "カスタム属性を追加"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:450
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:455
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
 #: src/pages/editor/Topbar/Topbar.tsx:110
 msgid "添加语句"

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -574,7 +574,7 @@ msgstr "删除"
 msgid "删除属性"
 msgstr "删除属性"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:379
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:365
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:36
 msgid "删除本句"
 msgstr "删除本句"
@@ -602,7 +602,7 @@ msgstr "刷新游戏"
 msgid "前景"
 msgstr "前景"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:129
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:131
 msgid "剪切"
 msgstr "剪切"
 
@@ -659,7 +659,7 @@ msgstr "取消"
 msgid "取消固定"
 msgstr "取消固定"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:119
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:121
 msgid "取消选择"
 msgstr "取消选择"
 
@@ -686,13 +686,13 @@ msgstr "右侧立绘"
 msgid "右对齐"
 msgstr "右对齐"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:136
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:409
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:138
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:414
 msgid "向上粘贴"
 msgstr "向上粘贴"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:141
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:425
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:143
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:430
 msgid "向下粘贴"
 msgstr "向下粘贴"
 
@@ -795,7 +795,7 @@ msgstr "场景与分支"
 msgid "场景文件"
 msgstr "场景文件"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:124
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:126
 msgid "复制"
 msgstr "复制"
 
@@ -1078,7 +1078,7 @@ msgstr "手动输入 ID"
 msgid "打开效果编辑器"
 msgstr "打开效果编辑器"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:389
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:375
 msgid "执行到此句"
 msgstr "执行到此句"
 
@@ -1441,7 +1441,7 @@ msgstr "未识别"
 msgid "未识别的指令"
 msgstr "未识别的指令"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:337
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:323
 msgid "本句前插入句子"
 msgstr "本句前插入句子"
 
@@ -1617,7 +1617,7 @@ msgstr "添加新行"
 msgid "添加自定义属性"
 msgstr "添加自定义属性"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:450
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:455
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
 #: src/pages/editor/Topbar/Topbar.tsx:110
 msgid "添加语句"

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -574,7 +574,7 @@ msgstr "删除"
 msgid "删除属性"
 msgstr "删除属性"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:249
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:379
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:36
 msgid "删除本句"
 msgstr "删除本句"
@@ -601,6 +601,10 @@ msgstr "刷新游戏"
 #: src/components/IconCreator/IconCreator.tsx:655
 msgid "前景"
 msgstr "前景"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:129
+msgid "剪切"
+msgstr "剪切"
 
 #: src/pages/editor/Topbar/Topbar.tsx:127
 msgid "功能区显示"
@@ -655,6 +659,10 @@ msgstr "取消"
 msgid "取消固定"
 msgstr "取消固定"
 
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:119
+msgid "取消选择"
+msgstr "取消选择"
+
 #: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:116
 msgid "变换"
 msgstr "变换"
@@ -677,6 +685,16 @@ msgstr "右侧立绘"
 #: src/pages/templateEditor/TemplateGraphicalEditor/WebgalClassEditor/propertyEditor/WGText.tsx:21
 msgid "右对齐"
 msgstr "右对齐"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:136
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:409
+msgid "向上粘贴"
+msgstr "向上粘贴"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:141
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:425
+msgid "向下粘贴"
+msgstr "向下粘贴"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:112
 msgid "启动、切换或停止背景音乐的播放"
@@ -776,6 +794,10 @@ msgstr "场景与分支"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeCallScene.tsx:27
 msgid "场景文件"
 msgstr "场景文件"
+
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:124
+msgid "复制"
+msgstr "复制"
 
 #: src/pages/templateEditor/TemplateEditorSidebar/ComponentTree/ComponentTree.tsx:41
 msgid "外层文本"
@@ -1056,7 +1078,7 @@ msgstr "手动输入 ID"
 msgid "打开效果编辑器"
 msgstr "打开效果编辑器"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:257
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:389
 msgid "执行到此句"
 msgstr "执行到此句"
 
@@ -1419,7 +1441,7 @@ msgstr "未识别"
 msgid "未识别的指令"
 msgstr "未识别的指令"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:220
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:337
 msgid "本句前插入句子"
 msgstr "本句前插入句子"
 
@@ -1595,7 +1617,7 @@ msgstr "添加新行"
 msgid "添加自定义属性"
 msgstr "添加自定义属性"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:273
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:450
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:71
 #: src/pages/editor/Topbar/Topbar.tsx:110
 msgid "添加语句"
@@ -1784,14 +1806,23 @@ msgstr "立绘文件"
 msgid "简体中文"
 msgstr "简体中文"
 
-#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:90
-#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:103
-msgid "红色通道"
-msgstr "红色通道"
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:94
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:372
+#~ msgid "粘贴"
+#~ msgstr "粘贴"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:208
 msgid "紧急回避"
 msgstr "紧急回避"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
+msgid "繁体中文"
+msgstr "繁体中文"
+
+#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:90
+#: src/pages/editor/GraphicalEditor/utils/useEffectEditorConfig.ts:103
+msgid "红色通道"
+msgstr "红色通道"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:121
 msgid "纹理"
@@ -1894,10 +1925,6 @@ msgstr "编辑游戏"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "编辑组件"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:235
-msgid "繁体中文"
-msgstr "繁体中文"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -1,7 +1,7 @@
 import { useValue } from '../../../hooks/useValue';
 import { parseScene } from './parser';
 import axios from 'axios';
-import { MouseEvent, useEffect, useMemo, useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState, useRef } from 'react';
 import { WsUtil } from '../../../utils/wsUtil';
 import { mergeToString, splitToArray } from './utils/sceneTextProcessor';
 import styles from './graphicalEditor.module.scss';
@@ -37,6 +37,9 @@ interface SentenceItem {
 
 export default function GraphicalEditor(props: IGraphicalEditorProps) {
   const sentenceData = useValue<SentenceItem[]>([]);
+
+  const sentenceDataRef = useRef(sentenceData);
+  sentenceDataRef.current = sentenceData;
 
   const [EditorOpState, setEditorOpState] = useState<EditorStateProps>({
     selectRaw: null,
@@ -79,7 +82,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
 
   // 复制
   const copyEvent = (e: MouseEvent, index: number) => {
-    const raw = sentenceData.value[index];
+    const raw = sentenceDataRef.current.value[index];
     setEditorOpState((v) => ({ ...v, clipStack: [raw, ...v.clipStack] }));
   };
 

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -19,9 +19,9 @@ import type { DropResult } from 'react-beautiful-dnd';
 interface EditorStateProps {
   selectRaw: null | SentenceItem;
   isCutting: boolean; // 剪切状态
-  // 剪贴板历史
+  // 剪贴板栈
   // 最新加入的元素总是在第一个
-  clipHistory: SentenceItem[];
+  clipStack: SentenceItem[];
 }
 
 interface IGraphicalEditorProps {
@@ -41,7 +41,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
   const [EditorOpState, setEditorOpState] = useState<EditorStateProps>({
     selectRaw: null,
     isCutting: false,
-    clipHistory: [],
+    clipStack: [],
   });
 
   function submitScene(newSentences: SentenceItem[], index: number) {
@@ -74,18 +74,18 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
 
   const resetSelect = (e: MouseEvent) => {
     e.stopPropagation();
-    setEditorOpState((v) => ({ ...v, select: null, selectRaw: null, clipHistory: [] }));
+    setEditorOpState((v) => ({ ...v, select: null, selectRaw: null, clipStack: [] }));
   };
 
   // 复制
   const copyEvent = (e: MouseEvent, index: number) => {
     const raw = sentenceData.value[index];
-    setEditorOpState((v) => ({ ...v, clipHistory: [raw, ...v.clipHistory] }));
+    setEditorOpState((v) => ({ ...v, clipStack: [raw, ...v.clipStack] }));
   };
 
   // 粘贴
   const pasteEvent = (e: MouseEvent, index: number, direction: 'up' | 'down' = 'up') => {
-    const raw = EditorOpState.clipHistory[0];
+    const raw = EditorOpState.clipStack[0];
     if (raw) {
       const newSentences = [...sentenceData.value];
       if (direction === 'up') {
@@ -96,7 +96,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
       sentenceData.set(newSentences);
       submitScene(newSentences, direction === 'down' ? index + 1 : index);
       if (EditorOpState.isCutting) {
-        setEditorOpState((v) => ({ ...v, selectRaw: null, clipHistory: v.clipHistory.slice(1), isCutting: false }));
+        setEditorOpState((v) => ({ ...v, selectRaw: null, clipStack: v.clipStack.slice(1), isCutting: false }));
       }
     }
   };
@@ -104,7 +104,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
   // 剪切
   const cutEvent = (e: MouseEvent, index: number) => {
     const raw = sentenceData.value[index];
-    setEditorOpState((v) => ({ ...v, clipHistory: [raw, ...v.clipHistory], isCutting: true }));
+    setEditorOpState((v) => ({ ...v, clipStack: [raw, ...v.clipStack], isCutting: true }));
     const newSentences = [...sentenceData.value];
     newSentences.splice(index, 1);
     sentenceData.set(newSentences);
@@ -128,7 +128,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
         icon: CuttingOne,
         click: cutEvent,
       },
-      ...(EditorOpState.clipHistory.length
+      ...(EditorOpState.clipStack.length
         ? [
           {
             name: t`向上粘贴`,
@@ -143,7 +143,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
         ]
         : []),
     ],
-    [EditorOpState.clipHistory],
+    [EditorOpState.clipStack],
   );
 
   function fetchScene() {
@@ -391,7 +391,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
                                       </div>
                                     ))}
                                   {EditorOpState.selectRaw?.id !== sentenceItem.id &&
-                                    !!EditorOpState.clipHistory.length && (
+                                    !!EditorOpState.clipStack.length && (
                                     <>
                                       <div
                                         className={styles.optionButton}

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -94,7 +94,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
         newSentences.splice(index + 1, 0, generateSentenceItem(raw.content));
       }
       sentenceData.set(newSentences);
-      submitScene(newSentences, index);
+      submitScene(newSentences, direction === 'down' ? index + 1 : index);
       if (EditorOpState.isCutting) {
         setEditorOpState((v) => ({ ...v, selectRaw: null, clipHistory: v.clipHistory.slice(1), isCutting: false }));
       }
@@ -108,7 +108,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     const newSentences = [...sentenceData.value];
     newSentences.splice(index, 1);
     sentenceData.set(newSentences);
-    submitScene(newSentences, index);
+    submitScene(newSentences, Math.min(index, newSentences.length - 1));
   };
 
   const selectStateBtns = useMemo(

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -1,20 +1,28 @@
-import {useValue} from "../../../hooks/useValue";
-import {parseScene} from "./parser";
-import axios from "axios";
-import {useEffect, useMemo} from "react";
-import {WsUtil} from "../../../utils/wsUtil";
-import {mergeToString, splitToArray} from "./utils/sceneTextProcessor";
-import styles from "./graphicalEditor.module.scss";
-import {DragDropContext, Draggable, Droppable} from "react-beautiful-dnd";
-import {sentenceEditorConfig, sentenceEditorDefault} from "./SentenceEditor";
-import {DeleteFive, Sort, DownOne, RightOne, Play} from "@icon-park/react";
-import AddSentence, {addSentenceType} from "./components/AddSentence";
-import {editorLineHolder} from "@/runtime/WG_ORIGINE_RUNTIME";
-import {eventBus} from "@/utils/eventBus";
-import { t } from "@lingui/macro";
-import { api } from "@/api";
+import { useValue } from '../../../hooks/useValue';
+import { parseScene } from './parser';
+import axios from 'axios';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
+import { WsUtil } from '../../../utils/wsUtil';
+import { mergeToString, splitToArray } from './utils/sceneTextProcessor';
+import styles from './graphicalEditor.module.scss';
+import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+import { sentenceEditorConfig, sentenceEditorDefault } from './SentenceEditor';
+import { DeleteFive, Sort, DownOne, RightOne, Play, ExcludeSelection, Copy, CuttingOne, Log } from '@icon-park/react';
+import AddSentence, { addSentenceType } from './components/AddSentence';
+import { editorLineHolder } from '@/runtime/WG_ORIGINE_RUNTIME';
+import { eventBus } from '@/utils/eventBus';
+import { t } from '@lingui/macro';
+import { api } from '@/api';
 
 import type { DropResult } from 'react-beautiful-dnd';
+
+interface EditorStateProps {
+  selectRaw: null | SentenceItem;
+  isCutting: boolean; // 剪切状态
+  // 剪贴板历史
+  // 最新加入的元素总是在第一个
+  clipHistory: SentenceItem[];
+}
 
 interface IGraphicalEditorProps {
   targetPath: string;
@@ -30,11 +38,131 @@ interface SentenceItem {
 export default function GraphicalEditor(props: IGraphicalEditorProps) {
   const sentenceData = useValue<SentenceItem[]>([]);
 
+  const [EditorOpState, setEditorOpState] = useState<EditorStateProps>({
+    selectRaw: null,
+    isCutting: false,
+    clipHistory: [],
+  });
+
+  const contextValueMemo = useMemo(() => ({ ...EditorOpState }), [EditorOpState]);
+
+  function submitScene(newSentences: SentenceItem[], index: number) {
+    const newScene = mergeToString(newSentences.map((item) => item.content));
+    const updateIndex = index + 1;
+    editorLineHolder.recordSceneEditingLine(props.targetPath, updateIndex);
+
+    api
+      .assetsControllerEditTextFile({
+        textFile: newScene,
+        path: props.targetPath,
+      })
+      .then(() => {
+        const targetValue = newSentences[index].content;
+        WsUtil.sendSyncCommand(props.targetPath, updateIndex, targetValue);
+        fetchScene();
+      });
+  }
+
   const generateSentenceItem = (content: string): SentenceItem => ({
     id: crypto.randomUUID(),
     content,
     show: true,
   });
+
+  const setSelect = (index: number) => {
+    const raw = sentenceData.value[index];
+    setEditorOpState((v) => ({ ...v, select: index, selectRaw: raw }));
+  };
+
+  const resetSelect = (e: MouseEvent) => {
+    e.stopPropagation();
+    setEditorOpState((v) => ({ ...v, select: null, selectRaw: null, clipHistory: [] }));
+  };
+
+  // 复制
+  const copyEvent = (e: MouseEvent, index: number) => {
+    const raw = sentenceData.value[index];
+    setEditorOpState((v) => ({ ...v, clipHistory: [raw, ...v.clipHistory] }));
+  };
+
+  // 粘贴
+  const pasteEvent = (e: MouseEvent, index: number, direction: 'up' | 'down' = 'up') => {
+    const raw = EditorOpState.clipHistory[0];
+    if (raw) {
+      const newSentences = [...sentenceData.value];
+      if (direction === 'up') {
+        newSentences.splice(index, 0, generateSentenceItem(raw.content));
+      } else if (direction === 'down') {
+        newSentences.splice(index + 1, 0, generateSentenceItem(raw.content));
+      }
+      sentenceData.set(newSentences);
+      submitScene(newSentences, index);
+      if (EditorOpState.isCutting) {
+        setEditorOpState((v) => ({ ...v, selectRaw: null, clipHistory: v.clipHistory.slice(1), isCutting: false }));
+      }
+    }
+  };
+
+  // 剪切
+  const cutEvent = (e: MouseEvent, index: number) => {
+    const raw = sentenceData.value[index];
+    setEditorOpState((v) => ({ ...v, clipHistory: [raw, ...v.clipHistory], isCutting: true }));
+    const newSentences = [...sentenceData.value];
+    newSentences.splice(index, 1);
+    sentenceData.set(newSentences);
+    submitScene(newSentences, index);
+  };
+
+  const selectStateBtns = useMemo(
+    () => [
+      {
+        name: t`取消选择`,
+        icon: ExcludeSelection,
+        click: (e: MouseEvent) => resetSelect(e),
+      },
+      {
+        name: t`复制`,
+        icon: Copy,
+        click: copyEvent,
+      },
+      {
+        name: t`剪切`,
+        icon: CuttingOne,
+        click: cutEvent,
+      },
+      ...(EditorOpState.clipHistory.length
+        ? [
+          {
+            name: t`向上粘贴`,
+            icon: Log,
+            click: (e: MouseEvent, index: number) => pasteEvent(e, index, 'up'),
+          },
+          {
+            name: t`向下粘贴`,
+            icon: Log,
+            click: (e: MouseEvent, index: number) => pasteEvent(e, index, 'down'),
+          },
+        ]
+        : []),
+    ],
+    [EditorOpState.clipHistory],
+  );
+
+  // eslint-disable-next-line react/no-unstable-nested-components
+  const SelectStateElement = ({ index: parentIndex }: { index: number }) =>
+    selectStateBtns.map((v, index) => (
+      <div
+        key={index + parentIndex + v.name}
+        className={styles.optionButton}
+        onClick={(e) => {
+          e.stopPropagation();
+          v.click(e, parentIndex);
+        }}
+      >
+        <v.icon strokeWidth={3} style={{ padding: '2px 4px 0 0' }} theme="outline" size="14" fill="var(--text)" />
+        <div>{v.name}</div>
+      </div>
+    ));
 
   function fetchScene() {
     const processFetchedData = (data: object) => {
@@ -81,21 +209,6 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);
-
-  function submitScene(newSentences: SentenceItem[], index: number) {
-    const newScene = mergeToString(newSentences.map(item => item.content));
-    const updateIndex = index + 1;
-    editorLineHolder.recordSceneEditingLine(props.targetPath, updateIndex);
-
-    api.assetsControllerEditTextFile({
-      textFile: newScene,
-      path: props.targetPath
-    }).then(() => {
-      const targetValue = newSentences[index].content;
-      WsUtil.sendSyncCommand(props.targetPath, updateIndex, targetValue);
-      fetchScene();
-    });
-  }
 
   function updateSentenceByIndex(newContent: string, updateIndex: number) {
     const newSentences = [...sentenceData.value];
@@ -171,7 +284,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     addOneSentence(sentence, sentenceData.value.length);
   }
 
-  function handleAdd({ sentence } : { sentence: string }) {
+  function handleAdd({ sentence }: { sentence: string }) {
     addNewSentenceAttach(sentence);
   }
 
@@ -182,101 +295,170 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     };
   }, [sentenceData.value]);
 
-  const mergedSceneText = useMemo(() =>
-    mergeToString(sentenceData.value.map(item => item.content)),
-  [sentenceData.value]
+  const mergedSceneText = useMemo(
+    () => mergeToString(sentenceData.value.map((item) => item.content)),
+    [sentenceData.value],
   );
 
-  const parsedScene = mergedSceneText === "" ? {sentenceList: []} : parseScene(mergedSceneText);
+  const parsedScene = mergedSceneText === '' ? { sentenceList: [] } : parseScene(mergedSceneText);
 
-  return <div className={styles.main} id="graphical-editor-main">
-    <div style={{flex: 1, padding: '14px 4px 0 4px'}}>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="droppable">
-          {(provided) => (
-            // 下面开始书写容器
-            <div style={{height: "100%"}}
-              // provided.droppableProps应用的相同元素.
-              {...provided.droppableProps}
-              // 为了使 droppable 能够正常工作必须 绑定到最高可能的DOM节点中provided.innerRef.
-              ref={provided.innerRef}
-            >
-              {parsedScene.sentenceList.map((sentence, i) => {
-                // 实际显示的行数
-                const index = i + 1;
-                // console.log(sentence.command);
-                const sentenceConfig = sentenceEditorConfig.find((e) => e.type === sentence.command) ?? sentenceEditorDefault;
-                const SentenceEditor = sentenceConfig.component;
-                const sentenceItem = sentenceData.value[i];
-                return <Draggable key={sentenceItem.id} draggableId={sentenceItem.id} index={i}>
-                  {(provided) => (
-                    <div className={`${styles.sentenceEditorWrapper} sentence-block-${index}`}
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                    >
-                      <div className={styles.addForwardArea}>
-                        <div className={styles.addForwardAreaButtonGroup}>
-                          <div className={styles.addForwardAreaButton}>
-                            <AddSentence titleText={t`本句前插入句子`} type={addSentenceType.forward}
-                              onChoose={(newSentence) => addOneSentence(newSentence, i)}/>
-                          </div>
-                        </div>
-                      </div>
-                      <div className={styles.sentenceEditorContent}>
-                        <div className={styles.lineNumber}><span style={{padding: "0 6px 0 0"}}>{index}</span>
-                          <Sort {...provided.dragHandleProps} style={{padding: "5px 0 0 0"}} theme="outline" size="22"
-                            strokeWidth={3}/>
-                        </div>
-                        <div className={styles.seArea}>
-                          <div className={styles.head}>
-                            <div className={styles.title}>
-                              {sentenceConfig.title()}
-                            </div>
-                            <div className={styles.optionButton}
-                              onClick={() => changeShowSentence(i)}>
-                              {sentenceItem.show ?
-                                <DownOne strokeWidth={3} theme="outline" size="18"
-                                  fill="#005CAF"/> :
-                                <RightOne strokeWidth={3} theme="outline" size="18"
-                                  fill="#005CAF"/>}
-                            </div>
-                            <div className={styles.optionButtonContainer}>
-                              <div className={styles.optionButton}
-                                onClick={() => deleteOneSentence(i)}>
-                                <DeleteFive strokeWidth={3} style={{padding: "2px 4px 0 0"}} theme="outline" size="14"
-                                  fill="var(--text)"/>
-                                <div>
-                                  {t`删除本句`}
-                                </div>
-                              </div>
-                              <div className={styles.optionButton}
-                                onClick={() => syncToIndex(i)}>
-                                <Play strokeWidth={3} style={{padding: "2px 4px 0 0"}} theme="outline" size="14"
-                                  fill="var(--text)"/>
-                                <div>
-                                  {t`执行到此句`}
-                                </div>
+  return (
+    <div className={styles.main} id="graphical-editor-main">
+      <div style={{ flex: 1, padding: '14px 4px 0 4px' }}>
+        <DragDropContext onDragEnd={onDragEnd}>
+          <Droppable droppableId="droppable">
+            {(provided) => (
+              // 下面开始书写容器
+              <div
+                style={{ height: '100%' }}
+                // provided.droppableProps应用的相同元素.
+                {...provided.droppableProps}
+                // 为了使 droppable 能够正常工作必须 绑定到最高可能的DOM节点中provided.innerRef.
+                ref={provided.innerRef}
+              >
+                {parsedScene.sentenceList.map((sentence, i) => {
+                  // 实际显示的行数
+                  const index = i + 1;
+                  // console.log(sentence.command);
+                  const sentenceConfig =
+                    sentenceEditorConfig.find((e) => e.type === sentence.command) ?? sentenceEditorDefault;
+                  const SentenceEditor = sentenceConfig.component;
+                  const sentenceItem = sentenceData.value[i];
+                  return (
+                    <Draggable key={sentenceItem.id} draggableId={sentenceItem.id} index={i}>
+                      {(provided) => (
+                        <div
+                          className={`${styles.sentenceEditorWrapper} sentence-block-${index}`}
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                        >
+                          <div className={styles.addForwardArea}>
+                            <div className={styles.addForwardAreaButtonGroup}>
+                              <div className={styles.addForwardAreaButton}>
+                                <AddSentence
+                                  titleText={t`本句前插入句子`}
+                                  type={addSentenceType.forward}
+                                  onChoose={(newSentence) => addOneSentence(newSentence, i)}
+                                />
                               </div>
                             </div>
                           </div>
-                          {sentenceItem.show && <SentenceEditor sentence={sentence} index={index} onSubmit={(newSentence) => {
-                            updateSentenceByIndex(newSentence, i);
-                          }}/>}
+                          <div
+                            className={`${styles.sentenceEditorContent} ${
+                              EditorOpState.selectRaw?.id === sentenceItem.id && styles.sentenceEditorContent__Selected
+                            }`}
+                            onClick={() => setSelect(i)}
+                          >
+                            <div className={styles.lineNumber}>
+                              <span style={{ padding: '0 6px 0 0' }}>{index}</span>
+                              <Sort
+                                {...provided.dragHandleProps}
+                                style={{ padding: '5px 0 0 0' }}
+                                theme="outline"
+                                size="22"
+                                strokeWidth={3}
+                              />
+                            </div>
+                            <div className={styles.seArea}>
+                              <div className={styles.head}>
+                                <div className={styles.title}>{sentenceConfig.title()}</div>
+                                <div className={styles.optionButton} onClick={() => changeShowSentence(i)}>
+                                  {sentenceItem.show ? (
+                                    <DownOne strokeWidth={3} theme="outline" size="18" fill="#005CAF" />
+                                  ) : (
+                                    <RightOne strokeWidth={3} theme="outline" size="18" fill="#005CAF" />
+                                  )}
+                                </div>
+                                <div className={styles.optionButtonContainer}>
+                                  <div className={styles.optionButton} onClick={() => deleteOneSentence(i)}>
+                                    <DeleteFive
+                                      strokeWidth={3}
+                                      style={{ padding: '2px 4px 0 0' }}
+                                      theme="outline"
+                                      size="14"
+                                      fill="var(--text)"
+                                    />
+                                    <div>{t`删除本句`}</div>
+                                  </div>
+                                  <div className={styles.optionButton} onClick={() => syncToIndex(i)}>
+                                    <Play
+                                      strokeWidth={3}
+                                      style={{ padding: '2px 4px 0 0' }}
+                                      theme="outline"
+                                      size="14"
+                                      fill="var(--text)"
+                                    />
+                                    <div>{t`执行到此句`}</div>
+                                  </div>
+                                  {EditorOpState.selectRaw?.id === sentenceItem.id && <SelectStateElement index={i} />}
+                                  {EditorOpState.selectRaw?.id !== sentenceItem.id &&
+                                    !!EditorOpState.clipHistory.length && (
+                                    <>
+                                      <div
+                                        className={styles.optionButton}
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          pasteEvent(e, i, 'up');
+                                        }}
+                                      >
+                                        <Log
+                                          strokeWidth={3}
+                                          style={{ padding: '2px 4px 0 0' }}
+                                          theme="outline"
+                                          size="14"
+                                          fill="var(--text)"
+                                        />
+                                        <div>{t`向上粘贴`}</div>
+                                      </div>
+                                      <div
+                                        className={styles.optionButton}
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          pasteEvent(e, i, 'down');
+                                        }}
+                                      >
+                                        <Log
+                                          strokeWidth={3}
+                                          style={{ padding: '2px 4px 0 0' }}
+                                          theme="outline"
+                                          size="14"
+                                          fill="var(--text)"
+                                        />
+                                        <div>{t`向下粘贴`}</div>
+                                      </div>
+                                    </>
+                                  )}
+                                </div>
+                              </div>
+                              {sentenceItem.show && (
+                                <SentenceEditor
+                                  sentence={sentence}
+                                  index={index}
+                                  onSubmit={(newSentence) => {
+                                    updateSentenceByIndex(newSentence, i);
+                                  }}
+                                />
+                              )}
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                    </div>
-                  )}
-                </Draggable>;
-              })}
-              {provided.placeholder}
-              <div className={styles.addWrapper}>
-                <AddSentence titleText={t`添加语句`} type={addSentenceType.backward}
-                  onChoose={(newSentence) => addOneSentence(newSentence, sentenceData.value.length)}/>
+                      )}
+                    </Draggable>
+                  );
+                })}
+                {provided.placeholder}
+                <div className={styles.addWrapper}>
+                  <AddSentence
+                    titleText={t`添加语句`}
+                    type={addSentenceType.backward}
+                    onChoose={(newSentence) => addOneSentence(newSentence, sentenceData.value.length)}
+                  />
+                </div>
               </div>
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+            )}
+          </Droppable>
+        </DragDropContext>
+      </div>
     </div>
-  </div>;
+  );
 }

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -44,8 +44,6 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     clipHistory: [],
   });
 
-  const contextValueMemo = useMemo(() => ({ ...EditorOpState }), [EditorOpState]);
-
   function submitScene(newSentences: SentenceItem[], index: number) {
     const newScene = mergeToString(newSentences.map((item) => item.content));
     const updateIndex = index + 1;
@@ -148,22 +146,6 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     [EditorOpState.clipHistory],
   );
 
-  // eslint-disable-next-line react/no-unstable-nested-components
-  const SelectStateElement = ({ index: parentIndex }: { index: number }) =>
-    selectStateBtns.map((v, index) => (
-      <div
-        key={index + parentIndex + v.name}
-        className={styles.optionButton}
-        onClick={(e) => {
-          e.stopPropagation();
-          v.click(e, parentIndex);
-        }}
-      >
-        <v.icon strokeWidth={3} style={{ padding: '2px 4px 0 0' }} theme="outline" size="14" fill="var(--text)" />
-        <div>{v.name}</div>
-      </div>
-    ));
-
   function fetchScene() {
     const processFetchedData = (data: object) => {
       const text = data.toString();
@@ -177,7 +159,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
           : {
             id: crypto.randomUUID(),
             content,
-            show: existing?.show ?? true
+            show: existing?.show ?? true,
           };
       });
 
@@ -185,8 +167,9 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
       eventBus.emit('editor:update-scene', { scene: text });
     };
 
-    axios.get(props.targetPath)
-      .then(res => res.data)
+    axios
+      .get(props.targetPath)
+      .then((res) => res.data)
       .then(processFetchedData);
   }
 
@@ -252,15 +235,12 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
       return;
     }
     editorLineHolder.recordSceneEditingLine(props.targetPath, result.destination.index);
-    reorder(
-      result.source.index,
-      result.destination.index
-    );
+    reorder(result.source.index, result.destination.index);
   }
 
   function syncToIndex(index: number) {
-    const targetValue = sentenceData.value[index]?.content || "";
-    WsUtil.sendSyncCommand(props.targetPath, index + 1, targetValue,true);
+    const targetValue = sentenceData.value[index]?.content || '';
+    WsUtil.sendSyncCommand(props.targetPath, index + 1, targetValue, true);
     editorLineHolder.recordSceneEditingLine(props.targetPath, index + 1);
   }
 
@@ -269,7 +249,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     const scrollToFunc = () => {
       const targetBlock = document.querySelector(`.sentence-block-${targetLine}`);
       if (targetBlock) {
-        targetBlock?.scrollIntoView?.({behavior: 'auto'});
+        targetBlock?.scrollIntoView?.({ behavior: 'auto' });
       } else {
         console.log('Retry scroll to in 50ms');
         setTimeout(() => scrollToFunc(), 50);
@@ -390,7 +370,26 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
                                     />
                                     <div>{t`执行到此句`}</div>
                                   </div>
-                                  {EditorOpState.selectRaw?.id === sentenceItem.id && <SelectStateElement index={i} />}
+                                  {EditorOpState.selectRaw?.id === sentenceItem.id &&
+                                    selectStateBtns.map((v, btnInd) => (
+                                      <div
+                                        key={btnInd + i + v.name}
+                                        className={styles.optionButton}
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          v.click(e, i);
+                                        }}
+                                      >
+                                        <v.icon
+                                          strokeWidth={3}
+                                          style={{ padding: '2px 4px 0 0' }}
+                                          theme="outline"
+                                          size="14"
+                                          fill="var(--text)"
+                                        />
+                                        <div>{v.name}</div>
+                                      </div>
+                                    ))}
                                   {EditorOpState.selectRaw?.id !== sentenceItem.id &&
                                     !!EditorOpState.clipHistory.length && (
                                     <>

--- a/packages/origine2/src/pages/editor/GraphicalEditor/graphicalEditor.module.scss
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/graphicalEditor.module.scss
@@ -5,6 +5,7 @@
 }
 
 .sentenceEditorWrapper {
+  border: solid 1px transparent;
   display: flex;
   color: var(--text-sub);
   font-weight: bold;
@@ -19,6 +20,10 @@
   padding: 0px 4px 4px 4px;
   border: var(--border-md);
   border-radius: var(--radius-md);
+
+  &__Selected {
+    border: solid 1px var(--text-sub);
+  }
 }
 
 .lineNumber {
@@ -54,7 +59,7 @@
   font-size: 100%;
 }
 
-.optionButtonContainer{
+.optionButtonContainer {
   margin-left: auto;
   opacity: 0;
   display: flex;
@@ -64,7 +69,7 @@
   // padding: 2px;
 }
 
-.sentenceEditorWrapper:hover .optionButtonContainer{
+.sentenceEditorWrapper:hover .optionButtonContainer {
   opacity: 1;
 }
 
@@ -85,7 +90,7 @@
 }
 
 .optionButton:hover {
-  background: var(--bg-button-hover)
+  background: var(--bg-button-hover);
 }
 
 .topBar {
@@ -96,7 +101,7 @@
   justify-content: center;
 }
 
-.addWrapper{
+.addWrapper {
   display: flex;
   align-items: center;
   padding: 30px 16px 30px 16px;
@@ -111,7 +116,7 @@
 }
 
 .addForwardArea::after {
-  content: "";
+  content: '';
   position: absolute;
   top: 1.5px;
   left: 4px;


### PR DESCRIPTION
issue: #483 

图形化编辑器增加选择状态
<img width="1444" height="150" alt="image" src="https://github.com/user-attachments/assets/77e4bdff-48f6-473f-9857-b7b3f698ff35" />

增加复制、粘贴操作（鼠标放置在已选择指令上）
<img width="1425" height="237" alt="image" src="https://github.com/user-attachments/assets/d98cbd77-4443-4057-8040-0cf487fe96e6" />

（鼠标放置在其他指令上）
<img width="1425" height="246" alt="image" src="https://github.com/user-attachments/assets/7fa80099-8132-4a83-bc31-ce050b96aab7" />

目前需要实现的需求：
- 剪切板历史记录
- 剪切板栈限制

我初步实现是这样，还需进一步讨论和修改。
