### PR TITLE
feat: support json game config

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -26,11 +26,11 @@ msgstr "*Click this button to save changes after setting color picker"
 msgid "%"
 msgstr "%"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:193
 msgid "<0>应用新的模板</0>"
 msgstr "<0>Apply a new template</0>"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:173
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:172
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>Current template: {currentTemplateName}</0>"
 
@@ -162,17 +162,17 @@ msgstr "setTransition:;"
 msgid "Spine 动画"
 msgstr "Spine animation"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:138
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:121
 msgid "Steam AppID"
 msgstr "Steam AppID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:260
 #~ msgid "Steam 成就"
-#~ msgstr ""
+#~ msgstr "Steam achievement"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx:30
 #~ msgid "Steam 成就 ID"
-#~ msgstr ""
+#~ msgstr "Steam achievement ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:204
 msgid "unlockBgm:;"
@@ -270,7 +270,7 @@ msgstr "No concat with previous text"
 msgid "不显示角色名"
 msgstr "Hide the role name"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:244
 msgid "不设定"
 msgstr "Not set"
 
@@ -417,7 +417,7 @@ msgid "修改时间"
 msgstr "Last modified"
 
 #: src/components/IconCreator/IconCreator.tsx:621
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:206
 msgid "修改游戏图标"
 msgstr "Change game icon"
 
@@ -638,7 +638,7 @@ msgstr "Delete game"
 msgid "刷新"
 msgstr "Refresh"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:169
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:170
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:54
 msgid "刷新游戏"
 msgstr "Refresh game"
@@ -744,13 +744,13 @@ msgstr "Right Align"
 msgid "启动、切换或停止背景音乐的播放"
 msgstr "Start, switch or stop the playback of background music"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:163
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:158
 msgid "启动图"
 msgstr "Startup image"
 
 #: src/pages/editor/GraphicalEditor/components/SearchableCascader.tsx:227
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:216
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:230
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:188
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:81
 msgid "启用"
@@ -818,7 +818,7 @@ msgstr "Open in File Explorer"
 
 #: src/pages/dashboard/GameElement.tsx:97
 #: src/pages/dashboard/TemplateElement.tsx:91
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:175
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:176
 msgid "在新标签页中预览"
 msgstr "Preview in new tab"
 
@@ -827,7 +827,7 @@ msgid "在这里放置编辑组件"
 msgstr "Place editing components here"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:150
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:151
 msgid "场景"
 msgstr "Scene"
 
@@ -841,7 +841,7 @@ msgstr "Scene file"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx:39
 #~ msgid "填写 Steam 成就 ID"
-#~ msgstr ""
+#~ msgstr "Fill in Steam achievement ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx:60
 msgid "填写参数值"
@@ -917,7 +917,7 @@ msgstr "Positioning"
 #~ msgid "实时预览"
 #~ msgstr "Live preview"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:182
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:110
 msgid "实时预览关闭"
 msgstr "Live preview off"
@@ -926,7 +926,7 @@ msgstr "Live preview off"
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "Live preview fast-forwards the game to the edited statement, but with limitations. The effects of statements from previous scenes, such as variables, won't be reflected in the preview."
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:182
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:110
 msgid "实时预览打开"
 msgstr "Live preview on"
@@ -1087,7 +1087,7 @@ msgstr "Tiling"
 msgid "应用"
 msgstr "Apply"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:171
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:170
 msgid "应用的模板"
 msgstr "Applied template"
 
@@ -1120,7 +1120,7 @@ msgstr "Intensity"
 msgid "当前版本"
 msgstr "Current version"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:243
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:250
 msgid "德语"
 msgstr "German"
 
@@ -1461,7 +1461,7 @@ msgstr "None"
 msgid "无匹配选项"
 msgstr "No matching options"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:241
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:248
 msgid "日语"
 msgstr "Japanese"
 
@@ -1571,11 +1571,11 @@ msgstr "Title Button List"
 msgid "标题按钮文字"
 msgstr "Title Button Text"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:147
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
 msgid "标题背景图片"
 msgstr "Title background image"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:155
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:146
 msgid "标题背景音乐"
 msgstr "Title background music"
 
@@ -1645,7 +1645,7 @@ msgstr "This command will end the game"
 msgid "永不换行"
 msgstr "Never wrap"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:242
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:249
 msgid "法语"
 msgstr "French"
 
@@ -1745,17 +1745,17 @@ msgstr "Games"
 msgid "游戏列表"
 msgstr "Game list"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:113
 msgid "游戏包名"
 msgstr "Game package name"
 
 #: src/pages/dashboard/Sidebar.tsx:102
 #: src/pages/dashboard/Sidebar.tsx:111
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:122
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:89
 msgid "游戏名称"
 msgstr "Game name"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:200
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:199
 msgid "游戏图标"
 msgstr "Game icon"
 
@@ -1768,15 +1768,16 @@ msgstr "Game control"
 msgid "游戏目录"
 msgstr "Game directory"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:130
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:105
 msgid "游戏简介"
 msgstr "Game description"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:126
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:97
 msgid "游戏识别码"
 msgstr "Game ID"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:124
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:125
 msgid "游戏配置"
 msgstr "Game configuration"
 
@@ -1869,8 +1870,8 @@ msgstr "Video options"
 msgid "禁止跳过视频"
 msgstr "Disable skipping video"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:218
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:228
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:231
 msgid "禁用"
 msgstr "Disabled"
 
@@ -1906,7 +1907,7 @@ msgstr "ID of figure illustration"
 msgid "立绘文件"
 msgstr "Figure file"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:245
 msgid "简体中文"
 msgstr "Simplified Chinese"
 
@@ -1915,7 +1916,7 @@ msgstr "Simplified Chinese"
 msgid "红色通道"
 msgstr "Red channel"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:212
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:211
 msgid "紧急回避"
 msgstr "Emergency Evasion"
 
@@ -2021,7 +2022,7 @@ msgstr "Edit game"
 msgid "编辑组件"
 msgstr "Edit component"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:246
 msgid "繁体中文"
 msgstr "Traditional Chinese"
 
@@ -2131,7 +2132,7 @@ msgstr "Stage object control"
 msgid "舞台画面"
 msgstr "Stage"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:240
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:247
 msgid "英语"
 msgstr "English"
 
@@ -2318,7 +2319,7 @@ msgstr "Call Steam Interface, supports multiple parameters"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:264
 #~ msgid "调用 Steam 接口解锁成就"
-#~ msgstr ""
+#~ msgstr "Call Steam interface to unlock achievement"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeCallScene.tsx:36
 msgid "调用/切换场景"
@@ -2336,7 +2337,7 @@ msgstr "Call Scene"
 msgid "调用场景，新场景结束后返回父场景"
 msgstr "Call scene, return to parent scene after new scene ends"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:149
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:150
 msgid "资源"
 msgstr "Assets"
 
@@ -2424,7 +2425,7 @@ msgstr "Choose animation file"
 msgid "选择图片"
 msgstr "Choose image"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:372
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:383
 msgid "选择图片文件"
 msgstr "Choose image file"
 
@@ -2592,7 +2593,7 @@ msgstr "Rename game directory"
 msgid "鉴赏"
 msgstr "Appreciation"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:222
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:225
 msgid "鉴赏功能"
 msgstr "Gallery Feature"
 
@@ -2681,7 +2682,7 @@ msgstr "Preview"
 msgid "预览图标"
 msgstr "Preview icon"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:160
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:161
 msgid "预览窗口"
 msgstr "Preview window"
 
@@ -2768,7 +2769,7 @@ msgstr "Default 24 hours"
 msgid "默认值50"
 msgstr "Default 50"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:232
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
 msgid "默认语言"
 msgstr "Default Language"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -26,11 +26,11 @@ msgstr "*カラーピッカー設定後、このボタンで保存"
 msgid "%"
 msgstr "%"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:193
 msgid "<0>应用新的模板</0>"
 msgstr "<0>新しいテンプレートを適用する</0>"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:173
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:172
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>現在適用中のテンプレート：{currentTemplateName}</0>"
 
@@ -162,17 +162,17 @@ msgstr "setTransition:;"
 msgid "Spine 动画"
 msgstr "Spine アニメーション"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:138
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:121
 msgid "Steam AppID"
 msgstr "Steam AppID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:260
 #~ msgid "Steam 成就"
-#~ msgstr ""
+#~ msgstr "Steam 実績"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx:30
 #~ msgid "Steam 成就 ID"
-#~ msgstr ""
+#~ msgstr "Steam 実績 ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:204
 msgid "unlockBgm:;"
@@ -273,7 +273,7 @@ msgstr "前のテキストボックス内の文を結合しない"
 msgid "不显示角色名"
 msgstr "キャラクター名は設定不可"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:244
 msgid "不设定"
 msgstr "未設定"
 
@@ -420,7 +420,7 @@ msgid "修改时间"
 msgstr "最終更新"
 
 #: src/components/IconCreator/IconCreator.tsx:621
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:206
 msgid "修改游戏图标"
 msgstr "ゲームアイコンの変更"
 
@@ -641,7 +641,7 @@ msgstr "ゲームを削除"
 msgid "刷新"
 msgstr "更新"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:169
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:170
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:54
 msgid "刷新游戏"
 msgstr "ゲームをリフレッシュ"
@@ -747,13 +747,13 @@ msgstr "右揃え"
 msgid "启动、切换或停止背景音乐的播放"
 msgstr "BGMの再生を開始、切り替え、または停止する"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:163
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:158
 msgid "启动图"
 msgstr "ロゴ"
 
 #: src/pages/editor/GraphicalEditor/components/SearchableCascader.tsx:227
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:216
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:230
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:188
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:81
 msgid "启用"
@@ -821,7 +821,7 @@ msgstr "ファイルエクスプローラーで開く"
 
 #: src/pages/dashboard/GameElement.tsx:97
 #: src/pages/dashboard/TemplateElement.tsx:91
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:175
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:176
 msgid "在新标签页中预览"
 msgstr "新しいタブでプレビュー"
 
@@ -830,7 +830,7 @@ msgid "在这里放置编辑组件"
 msgstr "ここにコンポーネントを配置"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:150
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:151
 msgid "场景"
 msgstr "シーン"
 
@@ -844,7 +844,7 @@ msgstr "シーンファイル"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx:39
 #~ msgid "填写 Steam 成就 ID"
-#~ msgstr ""
+#~ msgstr "Steam 実績IDを入力"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx:60
 msgid "填写参数值"
@@ -920,7 +920,7 @@ msgstr "位置決め方法"
 #~ msgid "实时预览"
 #~ msgstr "リアルタイムプレビュー"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:182
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:110
 msgid "实时预览关闭"
 msgstr "リアルタイムプレビューオフ"
@@ -929,7 +929,7 @@ msgstr "リアルタイムプレビューオフ"
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "リアルタイムプレビューはゲームを制限付きで早送りし、以前のシーンの効果はマッピングされません。"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:182
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:110
 msgid "实时预览打开"
 msgstr "リアルタイムプレビューオン"
@@ -1090,7 +1090,7 @@ msgstr "タイリング"
 msgid "应用"
 msgstr "適用"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:171
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:170
 msgid "应用的模板"
 msgstr "すでに適用されているテンプレート"
 
@@ -1123,7 +1123,7 @@ msgstr "強度"
 msgid "当前版本"
 msgstr "現在のバージョン"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:243
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:250
 msgid "德语"
 msgstr "ドイツ語"
 
@@ -1460,7 +1460,7 @@ msgstr "Null"
 msgid "无匹配选项"
 msgstr "一致するオプションがありません"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:241
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:248
 msgid "日语"
 msgstr "日本語"
 
@@ -1570,11 +1570,11 @@ msgstr "タイトルボタンリスト"
 msgid "标题按钮文字"
 msgstr "タイトルボタンテキスト"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:147
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
 msgid "标题背景图片"
 msgstr "タイトルの背景画像"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:155
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:146
 msgid "标题背景音乐"
 msgstr "タイトルのBGM"
 
@@ -1644,7 +1644,7 @@ msgstr "このコマンドはすべてのゲームが終わるときに使用"
 msgid "永不换行"
 msgstr "折り返しなし"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:242
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:249
 msgid "法语"
 msgstr "フランス語"
 
@@ -1744,17 +1744,17 @@ msgstr "ゲーム"
 msgid "游戏列表"
 msgstr "ゲームリスト"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:113
 msgid "游戏包名"
 msgstr "パッケージ名"
 
 #: src/pages/dashboard/Sidebar.tsx:102
 #: src/pages/dashboard/Sidebar.tsx:111
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:122
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:89
 msgid "游戏名称"
 msgstr "ゲーム名"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:200
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:199
 msgid "游戏图标"
 msgstr "ゲームアイコン"
 
@@ -1767,15 +1767,16 @@ msgstr "ゲームコントロール"
 msgid "游戏目录"
 msgstr "ゲームディレクトリ"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:130
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:105
 msgid "游戏简介"
 msgstr "ゲーム概要"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:126
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:97
 msgid "游戏识别码"
 msgstr "ゲームID"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:124
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:125
 msgid "游戏配置"
 msgstr "ゲーム構成"
 
@@ -1868,8 +1869,8 @@ msgstr "動画のオプション"
 msgid "禁止跳过视频"
 msgstr "動画のスキップを無効にする"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:218
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:228
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:231
 msgid "禁用"
 msgstr "無効化"
 
@@ -1905,7 +1906,7 @@ msgstr "関連する立ち絵のID"
 msgid "立绘文件"
 msgstr "立ち絵ファイル"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:245
 msgid "简体中文"
 msgstr "簡体字中国語"
 
@@ -1914,7 +1915,7 @@ msgstr "簡体字中国語"
 msgid "红色通道"
 msgstr "赤いチャネル"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:212
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:211
 msgid "紧急回避"
 msgstr "緊急回避"
 
@@ -2020,7 +2021,7 @@ msgstr "ゲームの編集"
 msgid "编辑组件"
 msgstr "コンポーネントの編集"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:246
 msgid "繁体中文"
 msgstr "繁体字中国語"
 
@@ -2130,7 +2131,7 @@ msgstr "ステージオブジェクトコントロール"
 msgid "舞台画面"
 msgstr "ステージ画面"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:240
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:247
 msgid "英语"
 msgstr "英語"
 
@@ -2317,7 +2318,7 @@ msgstr "Steamインターフェースを呼び出し、複数のパラメータ�
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:264
 #~ msgid "调用 Steam 接口解锁成就"
-#~ msgstr ""
+#~ msgstr "Steamインターフェースを呼び出して実績を解除する"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeCallScene.tsx:36
 msgid "调用/切换场景"
@@ -2335,7 +2336,7 @@ msgstr "シーンを呼び出す"
 msgid "调用场景，新场景结束后返回父场景"
 msgstr "シーンを呼び出し、新しいシーン終了後に親シーンに戻る"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:149
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:150
 msgid "资源"
 msgstr "アセット"
 
@@ -2423,7 +2424,7 @@ msgstr "アニメーションファイルを選択"
 msgid "选择图片"
 msgstr "画像を選択"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:372
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:383
 msgid "选择图片文件"
 msgstr "画像ファイルを選択"
 
@@ -2591,7 +2592,7 @@ msgstr "ゲームディレクトリ名変更"
 msgid "鉴赏"
 msgstr "鑑賞"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:222
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:225
 msgid "鉴赏功能"
 msgstr "鑑賞機能"
 
@@ -2680,7 +2681,7 @@ msgstr "プレビュー"
 msgid "预览图标"
 msgstr "プレビューアイコン"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:160
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:161
 msgid "预览窗口"
 msgstr "プレビューウィンドウ"
 
@@ -2767,7 +2768,7 @@ msgstr "デフォルト値は24時間"
 msgid "默认值50"
 msgstr "デフォルト値は50"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:232
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
 msgid "默认语言"
 msgstr "デフォルト言語"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -26,11 +26,11 @@ msgstr "*设置拾色器后，点击此按钮以保存更改"
 msgid "%"
 msgstr "%"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:194
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:193
 msgid "<0>应用新的模板</0>"
 msgstr "<0>应用新的模板</0>"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:173
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:172
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>当前应用的模板：{currentTemplateName}</0>"
 
@@ -158,7 +158,7 @@ msgstr "setTransition:;"
 msgid "Spine 动画"
 msgstr "Spine 动画"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:138
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:121
 msgid "Steam AppID"
 msgstr "Steam AppID"
 
@@ -268,7 +268,7 @@ msgstr "不拼接先前文本框内的语句"
 msgid "不显示角色名"
 msgstr "不显示角色名"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:237
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:244
 msgid "不设定"
 msgstr "不设定"
 
@@ -415,7 +415,7 @@ msgid "修改时间"
 msgstr "修改时间"
 
 #: src/components/IconCreator/IconCreator.tsx:621
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:207
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:206
 msgid "修改游戏图标"
 msgstr "修改游戏图标"
 
@@ -636,7 +636,7 @@ msgstr "删除游戏"
 msgid "刷新"
 msgstr "刷新"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:169
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:170
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:54
 msgid "刷新游戏"
 msgstr "刷新游戏"
@@ -738,13 +738,13 @@ msgstr "右对齐"
 msgid "启动、切换或停止背景音乐的播放"
 msgstr "启动、切换或停止背景音乐的播放"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:163
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:158
 msgid "启动图"
 msgstr "启动图"
 
 #: src/pages/editor/GraphicalEditor/components/SearchableCascader.tsx:227
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:227
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:216
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:230
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:188
 #: src/pages/editor/Topbar/tabs/ViewConfig/ViewTab.tsx:81
 msgid "启用"
@@ -812,7 +812,7 @@ msgstr "在文件管理器中打开"
 
 #: src/pages/dashboard/GameElement.tsx:97
 #: src/pages/dashboard/TemplateElement.tsx:91
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:175
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:176
 msgid "在新标签页中预览"
 msgstr "在新标签页中预览"
 
@@ -821,7 +821,7 @@ msgid "在这里放置编辑组件"
 msgstr "在这里放置编辑组件"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:118
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:150
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:151
 msgid "场景"
 msgstr "场景"
 
@@ -911,7 +911,7 @@ msgstr "定位方式"
 #~ msgid "实时预览"
 #~ msgstr "实时预览"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:182
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:110
 msgid "实时预览关闭"
 msgstr "实时预览关闭"
@@ -920,7 +920,7 @@ msgstr "实时预览关闭"
 msgid "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 msgstr "实时预览将游戏快进至编辑语句，但有限制。先前场景的语句效果，如变量，不会反映在预览中。"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:181
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:182
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:110
 msgid "实时预览打开"
 msgstr "实时预览打开"
@@ -1081,7 +1081,7 @@ msgstr "平铺"
 msgid "应用"
 msgstr "应用"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:171
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:170
 msgid "应用的模板"
 msgstr "应用的模板"
 
@@ -1114,7 +1114,7 @@ msgstr "强度"
 msgid "当前版本"
 msgstr "当前版本"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:243
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:250
 msgid "德语"
 msgstr "德语"
 
@@ -1451,7 +1451,7 @@ msgstr "无"
 msgid "无匹配选项"
 msgstr "无匹配选项"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:241
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:248
 msgid "日语"
 msgstr "日语"
 
@@ -1561,11 +1561,11 @@ msgstr "标题按钮列表"
 msgid "标题按钮文字"
 msgstr "标题按钮文字"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:147
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
 msgid "标题背景图片"
 msgstr "标题背景图片"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:155
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:146
 msgid "标题背景音乐"
 msgstr "标题背景音乐"
 
@@ -1635,7 +1635,7 @@ msgstr "此指令将结束游戏"
 msgid "永不换行"
 msgstr "永不换行"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:242
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:249
 msgid "法语"
 msgstr "法语"
 
@@ -1735,17 +1735,17 @@ msgstr "游戏"
 msgid "游戏列表"
 msgstr "游戏列表"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:134
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:113
 msgid "游戏包名"
 msgstr "游戏包名"
 
 #: src/pages/dashboard/Sidebar.tsx:102
 #: src/pages/dashboard/Sidebar.tsx:111
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:122
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:89
 msgid "游戏名称"
 msgstr "游戏名称"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:200
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:199
 msgid "游戏图标"
 msgstr "游戏图标"
 
@@ -1758,15 +1758,16 @@ msgstr "游戏控制"
 msgid "游戏目录"
 msgstr "游戏目录"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:130
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:105
 msgid "游戏简介"
 msgstr "游戏简介"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:126
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:97
 msgid "游戏识别码"
 msgstr "游戏识别码"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:124
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:125
 msgid "游戏配置"
 msgstr "游戏配置"
 
@@ -1859,8 +1860,8 @@ msgstr "视频选项"
 msgid "禁止跳过视频"
 msgstr "禁止跳过视频"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:218
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:228
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:217
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:231
 msgid "禁用"
 msgstr "禁用"
 
@@ -1896,7 +1897,7 @@ msgstr "立绘插图的ID"
 msgid "立绘文件"
 msgstr "立绘文件"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:238
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:245
 msgid "简体中文"
 msgstr "简体中文"
 
@@ -1905,7 +1906,7 @@ msgstr "简体中文"
 msgid "红色通道"
 msgstr "红色通道"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:212
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:211
 msgid "紧急回避"
 msgstr "紧急回避"
 
@@ -2011,7 +2012,7 @@ msgstr "编辑游戏"
 msgid "编辑组件"
 msgstr "编辑组件"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:246
 msgid "繁体中文"
 msgstr "繁体中文"
 
@@ -2121,7 +2122,7 @@ msgstr "舞台对象控制"
 msgid "舞台画面"
 msgstr "舞台画面"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:240
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:247
 msgid "英语"
 msgstr "英语"
 
@@ -2326,7 +2327,7 @@ msgstr "调用场景"
 msgid "调用场景，新场景结束后返回父场景"
 msgstr "调用场景，新场景结束后返回父场景"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:149
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:150
 msgid "资源"
 msgstr "资源"
 
@@ -2414,7 +2415,7 @@ msgstr "选择动画文件"
 msgid "选择图片"
 msgstr "选择图片"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:372
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:383
 msgid "选择图片文件"
 msgstr "选择图片文件"
 
@@ -2582,7 +2583,7 @@ msgstr "重命名游戏目录"
 msgid "鉴赏"
 msgstr "鉴赏"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:222
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:225
 msgid "鉴赏功能"
 msgstr "鉴赏功能"
 
@@ -2671,7 +2672,7 @@ msgstr "预览"
 msgid "预览图标"
 msgstr "预览图标"
 
-#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:160
+#: src/pages/editor/EditorSidebar/EditorSidebar.tsx:161
 msgid "预览窗口"
 msgstr "预览窗口"
 
@@ -2758,7 +2759,7 @@ msgstr "默认值24小时"
 msgid "默认值50"
 msgstr "默认值50"
 
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:232
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:239
 msgid "默认语言"
 msgstr "默认语言"
 

--- a/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebar.tsx
+++ b/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebar.tsx
@@ -121,7 +121,8 @@ export default function EditorSideBar() {
     [`tex`, { desc: t`纹理`, extNameTypes: ['tex'], isProtected: true }],
     [`video`, { desc: t`视频`, extNameTypes: ['video'], isProtected: true }],
     [`vocal`, { desc: t`语音`, extNameTypes: ['audio'], isProtected: true }],
-    [`config.txt`, { desc: t`游戏配置`, isProtected: true }],
+    [`config.txt`, { desc: t`游戏配置`, isProtected: true }], // 旧版游戏配置文件
+    [`config.json`, { desc: t`游戏配置`, isProtected: true }],
     [`userStyleSheet.css`, { isProtected: true }],
   ]);
 

--- a/packages/origine2/src/types/gameConfig.ts
+++ b/packages/origine2/src/types/gameConfig.ts
@@ -1,0 +1,19 @@
+/**
+ * 游戏配置接口
+ */
+export interface IWebgalConfig {
+  gameName?: string; // 游戏名称
+  gameKey?: string; // 游戏Key
+  gameLogo?: string; // 游戏Logo
+  titleImage?: string; // 标题图片
+  titleBgm?: string; // 标题背景音乐
+  description?: string; // 游戏描述
+  defaultLanguage?: string; // 默认语言
+  packageName?: string; // 包名
+  steamAppId?: string; // Steam 应用 ID
+  enableExtra?: boolean; // 启用鉴赏功能
+  enablePanic?: boolean; // 启用紧急回避
+  enableLegacyExpressionBlendMode?: boolean; // 启用旧版 Live2D 表情混合模式
+  textboxMaxLine?: number; // 文字框最大行数
+  textboxLineHeight?: number; // 文字框行高
+}

--- a/packages/terre2/src/types/game-config.ts
+++ b/packages/terre2/src/types/game-config.ts
@@ -1,0 +1,19 @@
+/**
+ * 游戏配置接口
+ */
+export interface IWebgalConfig {
+  gameName?: string; // 游戏名称
+  gameKey?: string; // 游戏Key
+  gameLogo?: string; // 游戏Logo
+  titleImage?: string; // 标题图片
+  titleBgm?: string; // 标题背景音乐
+  description?: string; // 游戏描述
+  defaultLanguage?: string; // 默认语言
+  packageName?: string; // 包名
+  steamAppId?: string; // Steam 应用 ID
+  enableExtra?: boolean; // 启用鉴赏功能
+  enablePanic?: boolean; // 启用紧急回避
+  enableLegacyExpressionBlendMode?: boolean; // 启用旧版 Live2D 表情混合模式
+  textboxMaxLine?: number; // 文字框最大行数
+  textboxLineHeight?: number; // 文字框行高
+}

--- a/packages/terre2/src/util/convert-game-config.ts
+++ b/packages/terre2/src/util/convert-game-config.ts
@@ -1,0 +1,97 @@
+import { IWebgalConfig } from '../types/game-config';
+import { webgalParser } from '../util/webgal-parser';
+import { WebgalConfig } from 'webgal-parser/build/types/configParser/configParser';
+import { cloneDeep } from "lodash";
+
+// 转化旧版配置文件内容为新版配置
+export function convertTextConfigToWebgalConfig(textConfig: string): IWebgalConfig {
+  let config: IWebgalConfig = {};
+  const gameConfig: WebgalConfig = webgalParser.parseConfig(textConfig);
+  gameConfig.forEach((configItem) => {
+    switch (configItem.command) {
+      case 'Game_name':
+        if (configItem.args[0]) config.gameName = configItem.args[0];
+        break;
+      case 'Game_key':
+        if (configItem.args[0]) config.gameKey = configItem.args[0];
+        break;
+      case 'Game_Logo':
+        if (configItem.args) config.gameLogo = configItem.args.join('|');
+        break;
+      case 'Title_img':
+        if (configItem.args[0]) config.titleImage = configItem.args[0];
+        break;
+      case 'Title_bgm':
+        if (configItem.args[0]) config.titleBgm = configItem.args[0];
+        break;
+      case 'Description':
+        if (configItem.args[0]) config.description = configItem.args[0];
+        break;
+      case 'Default_Language':
+        if (configItem.args[0]) config.defaultLanguage = configItem.args[0];
+        break;
+      case 'Package_name':
+        if (configItem.args[0]) config.packageName = configItem.args[0];
+        break;
+      case 'Enable_Appreciation':
+        if (configItem.args[0])
+          config.enableExtra = configItem.args[0] === 'true';
+        break;
+      case 'Enable_Panic':
+        if (configItem.args[0])
+          config.enablePanic = configItem.args[0] === 'true';
+        break;
+      case 'Enable_Legacy_Expression_Blend_Mode':
+        if (configItem.args[0])
+          config.enableLegacyExpressionBlendMode = configItem.args[0] === 'true';
+        break;
+      case 'Steam_AppID':
+        if (configItem.args[0]) config.steamAppId = configItem.args[0];
+        break;
+      case 'Max_line':
+        if (configItem.args[0]) config.textboxMaxLine = parseInt(configItem.args[0], 10);
+        break;
+      case 'LineHeight':
+        if (configItem.args[0]) config.textboxLineHeight = parseInt(configItem.args[0], 10);
+        break;
+      default:
+        config[configItem.command] = cloneDeep(configItem.args).join('|');
+        break;
+    }
+  });
+  return config;
+}
+
+// 转化新版配置为旧版配置文件内容
+export function convertWebgalConfigToTextConfig(webgalConfig: IWebgalConfig): string {
+  let legacyConfig: WebgalConfig = [];
+  if (webgalConfig.gameName)
+    legacyConfig.push({ command: 'Game_name', args: [webgalConfig.gameName], options: [] });
+  if (webgalConfig.gameKey)
+    legacyConfig.push({ command: 'Game_key', args: [webgalConfig.gameKey], options: [] });
+  if (webgalConfig.gameLogo && webgalConfig.gameLogo.length > 0)
+    legacyConfig.push({ command: 'Game_Logo', args: webgalConfig.gameLogo.split('|'), options: [] });
+  if (webgalConfig.titleImage)
+    legacyConfig.push({ command: 'Title_img', args: [webgalConfig.titleImage], options: [] });
+  if (webgalConfig.titleBgm)
+    legacyConfig.push({ command: 'Title_bgm', args: [webgalConfig.titleBgm], options: [] });
+  if (webgalConfig.description)
+    legacyConfig.push({ command: 'Description', args: [webgalConfig.description], options: [] });
+  if (webgalConfig.defaultLanguage)
+    legacyConfig.push({ command: 'Default_Language', args: [webgalConfig.defaultLanguage], options: [] });
+  if (webgalConfig.packageName)
+    legacyConfig.push({ command: 'Package_name', args: [webgalConfig.packageName], options: [] });
+  if (webgalConfig.enableExtra !== undefined)
+    legacyConfig.push({ command: 'Enable_Appreciation', args: [webgalConfig.enableExtra ? 'true' : 'false'], options: [] });
+  if (webgalConfig.enablePanic !== undefined)
+    legacyConfig.push({ command: 'Enable_Panic', args: [webgalConfig.enablePanic ? 'true' : 'false'], options: [] });
+  if (webgalConfig.enableLegacyExpressionBlendMode !== undefined)
+    legacyConfig.push({ command: 'Enable_Legacy_Expression_Blend_Mode', args: [webgalConfig.enableLegacyExpressionBlendMode ? 'true' : 'false'], options: [] });
+  if (webgalConfig.steamAppId)
+    legacyConfig.push({ command: 'Steam_AppID', args: [webgalConfig.steamAppId], options: [] });
+  if (webgalConfig.textboxMaxLine !== undefined)
+    legacyConfig.push({ command: 'Max_line', args: [webgalConfig.textboxMaxLine.toString()], options: [] });
+  if (webgalConfig.textboxLineHeight !== undefined)
+    legacyConfig.push({ command: 'LineHeight', args: [webgalConfig.textboxLineHeight.toString()], options: [] });
+  return webgalParser.stringifyConfig(legacyConfig);
+}


### PR DESCRIPTION
# 介绍
支持 JSON 格式的游戏配置, 同时兼容旧版本的 txt 格式的游戏配置

# 更改
- 优先寻找 config.txt, 然后才找 config.json
- 无论哪种格式, 都统一返回 IWebgalConfig, 适当的时候会相互转换旧版配置和新版配置
- 理论上旧版配置不应再添加新的配置项
- 创建游戏时自动覆写 game key 为随机值, 以免所有新创建的游戏都使用引擎自带的默认 game key