### PR TITLE
fix: complete file icon mappings

### DIFF
--- a/packages/origine2/src/utils/getFileIcon.ts
+++ b/packages/origine2/src/utils/getFileIcon.ts
@@ -17,8 +17,8 @@ export function extractExtension(filename: string): FileType {
   const extension = filename.split(".").pop()?.toLowerCase() ?? "unknown";
 
   const imageExtensions = ["jpg", "jpeg", "png", "gif", "bmp", "svg", "webp"];
-  const videoExtensions = ["mp4", "webm", "ogg"];
-  const audioExtensions = ["wav", "mp3", "ogg"];
+  const videoExtensions = ["mp4", "webm", "mkv", "ogg"];
+  const audioExtensions = ["wav", "mp3", "flac", "aac", "opus", "ogg"];
 
   if (imageExtensions.includes(extension)) {
     return "image";


### PR DESCRIPTION
## Summary

- map `.flac`, `.aac`, and `.opus` files to the audio icon
- map `.mkv` files to the video icon
- align file icon classification with formats already supported elsewhere in Origine

## Validation

- `yarn workspace webgal-origine-2 build`

Closes #586
