### PR TITLE
fix: hide local folder actions on remote hosts

### DIFF
--- a/packages/origine2/src/components/Assets/Assets.tsx
+++ b/packages/origine2/src/components/Assets/Assets.tsx
@@ -58,6 +58,7 @@ import Upload from './Upload';
 import naturalCompare from 'natural-compare-lite';
 import useEditorStore from '@/store/useEditorStore';
 import useTrashFailedToast from '@/hooks/useTrashFailedToast';
+import { isLocalBrowserHost } from '@/utils/isLocalBrowserHost';
 
 export interface IFile {
   extName: string;
@@ -136,6 +137,7 @@ export default function Assets({
   const updateSortOrder = useEditorStore.use.updateSortOrder();
   const isTrash = useEditorStore.use.isTrash();
   const toastTrashFailed = useTrashFailedToast();
+  const canOpenLocalFolder = isLocalBrowserHost();
 
   const currentPath = useValue([...basePath, ...selectedFilePath.slice(0, -1)]);
   const currentFullPath = useMemo(() => [...rootPath, ...currentPath.value], [currentPath.value]);
@@ -589,7 +591,9 @@ export default function Assets({
             <MenuPopover>
               <MenuList>
                 <MenuItem icon={<ArrowSyncIcon />} onClick={handleRefresh}>{t`刷新`}</MenuItem>
-                <MenuItem icon={<FolderOpenIcon />} onClick={handleOpenFolder}>{t`在文件管理器中打开`}</MenuItem>
+                {canOpenLocalFolder && (
+                  <MenuItem icon={<FolderOpenIcon />} onClick={handleOpenFolder}>{t`在文件管理器中打开`}</MenuItem>
+                )}
                 <Menu>
                   <MenuTrigger>
                     <MenuItem icon={<ArrowSortIcon />}>{t`排序方式`}</MenuItem>

--- a/packages/origine2/src/components/UserDataSettings/UserDataSettingsDialog.tsx
+++ b/packages/origine2/src/components/UserDataSettings/UserDataSettingsDialog.tsx
@@ -15,6 +15,7 @@ import useSWR, { mutate } from 'swr';
 import { t } from '@lingui/macro';
 import useEditorStore from '@/store/useEditorStore';
 import { getMigrationGuideUrl } from '@/utils/language';
+import { isLocalBrowserHost } from '@/utils/isLocalBrowserHost';
 import styles from './UserDataSettingsDialog.module.scss';
 
 declare global {
@@ -72,6 +73,7 @@ export function UserDataSettingsPanel() {
   const [busy, setBusy] = useState(false);
   const language = useEditorStore.use.language();
   const migrationGuideUrl = getMigrationGuideUrl(language);
+  const canOpenLocalFolder = isLocalBrowserHost();
 
   useEffect(() => {
     if (status) setTargetPath(status.configuredUserDataRoot);
@@ -207,17 +209,19 @@ export function UserDataSettingsPanel() {
                 {status.configRoot}
               </div>
             </div>
-            <div className={styles.actions}>
-              <Button icon={<FolderOpen20Regular />} onClick={() => openPath('active')}>
-                {t`打开用户数据目录`}
-              </Button>
-              <Button icon={<FolderOpen20Regular />} onClick={() => openPath('config')}>
-                {t`打开配置目录`}
-              </Button>
-              <Button icon={<FolderOpen20Regular />} onClick={() => openPath('app')}>
-                {t`打开安装目录`}
-              </Button>
-            </div>
+            {canOpenLocalFolder && (
+              <div className={styles.actions}>
+                <Button icon={<FolderOpen20Regular />} onClick={() => openPath('active')}>
+                  {t`打开用户数据目录`}
+                </Button>
+                <Button icon={<FolderOpen20Regular />} onClick={() => openPath('config')}>
+                  {t`打开配置目录`}
+                </Button>
+                <Button icon={<FolderOpen20Regular />} onClick={() => openPath('app')}>
+                  {t`打开安装目录`}
+                </Button>
+              </div>
+            )}
           </div>
 
           <div className={styles.section}>

--- a/packages/origine2/src/pages/dashboard/GameElement.tsx
+++ b/packages/origine2/src/pages/dashboard/GameElement.tsx
@@ -38,6 +38,7 @@ import { t } from '@lingui/macro';
 import { GameInfoDto } from '@/api/Api';
 import useEditorStore from '@/store/useEditorStore';
 import useTrashFailedToast from '@/hooks/useTrashFailedToast';
+import { isLocalBrowserHost } from '@/utils/isLocalBrowserHost';
 
 interface IGameElementProps {
   gameInfo: GameInfoDto;
@@ -74,6 +75,7 @@ export default function GameElement(props: IGameElementProps) {
   const deleteChecked = useValue(false);
   const isTrash = useEditorStore.use.isTrash();
   const toastTrashFailed = useTrashFailedToast();
+  const canOpenLocalFolder = isLocalBrowserHost();
 
   const openInFileExplorer = () => {
     api.manageGameControllerOpenGameDict(props.gameInfo.dir);
@@ -130,10 +132,12 @@ export default function GameElement(props: IGameElementProps) {
               </MenuTrigger>
               <MenuPopover>
                 <MenuList>
-                  <MenuItem
-                    icon={<FolderOpenIcon />}
-                    onClick={() => openInFileExplorer()}
-                  >{t`在文件管理器中打开`}</MenuItem>
+                  {canOpenLocalFolder && (
+                    <MenuItem
+                      icon={<FolderOpenIcon />}
+                      onClick={() => openInFileExplorer()}
+                    >{t`在文件管理器中打开`}</MenuItem>
+                  )}
                   <MenuItem icon={<OpenIcon />} onClick={() => previewInNewTab()}>{t`在新标签页中预览`}</MenuItem>
                   <MenuItem
                     icon={<RenameIcon />}

--- a/packages/origine2/src/pages/dashboard/TemplateElement.tsx
+++ b/packages/origine2/src/pages/dashboard/TemplateElement.tsx
@@ -40,6 +40,7 @@ import { localStorageRename } from '@/utils/localStorageRename';
 import { TemplateInfoDto } from '@/api/Api';
 import useEditorStore from '@/store/useEditorStore';
 import useTrashFailedToast from '@/hooks/useTrashFailedToast';
+import { isLocalBrowserHost } from '@/utils/isLocalBrowserHost';
 
 interface ITemplateElementProps {
   templateInfo: TemplateInfoDto;
@@ -75,6 +76,7 @@ export default function TemplateElement(props: ITemplateElementProps) {
   const newTemplateName = useValue(props.templateInfo.dir);
   const isTrash = useEditorStore.use.isTrash();
   const toastTrashFailed = useTrashFailedToast();
+  const canOpenLocalFolder = isLocalBrowserHost();
 
   const openInFileExplorer = () => {
     api.assetsControllerOpenDict(`templates/${props.templateInfo.dir}`);
@@ -146,10 +148,12 @@ export default function TemplateElement(props: ITemplateElementProps) {
               </MenuTrigger>
               <MenuPopover>
                 <MenuList>
-                  <MenuItem
-                    icon={<FolderOpenIcon />}
-                    onClick={() => openInFileExplorer()}
-                  >{t`在文件管理器中打开`}</MenuItem>
+                  {canOpenLocalFolder && (
+                    <MenuItem
+                      icon={<FolderOpenIcon />}
+                      onClick={() => openInFileExplorer()}
+                    >{t`在文件管理器中打开`}</MenuItem>
+                  )}
                   <MenuItem icon={<OpenIcon />} onClick={() => previewInNewTab()}>{t`在新标签页中预览`}</MenuItem>
                   <MenuItem
                     disabled={isBuiltIn}

--- a/packages/origine2/src/utils/isLocalBrowserHost.ts
+++ b/packages/origine2/src/utils/isLocalBrowserHost.ts
@@ -1,0 +1,4 @@
+export function isLocalBrowserHost(hostname = window.location.hostname): boolean {
+  const normalizedHostname = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  return normalizedHostname === 'localhost' || normalizedHostname === '::1' || /^127(?:\.\d{1,3}){3}$/.test(normalizedHostname);
+}


### PR DESCRIPTION
## Summary

- detect localhost, IPv4 loopback, and IPv6 loopback browser hosts
- hide file-manager actions for games, templates, assets, and user-data paths when Terre is accessed remotely
- keep directory selection/migration controls available because they are separate workflows

## Validation

- `yarn workspace webgal-origine-2 build`
- checked 8 local/remote hostname cases with `tsx`

Closes #594