### PR TITLE
fix: 修复游戏封面图无法显示的问题 (#643)

### DIFF
--- a/packages/origine2/src/pages/dashboard/GameElement.tsx
+++ b/packages/origine2/src/pages/dashboard/GameElement.tsx
@@ -53,7 +53,7 @@ const RenameIcon = bundleIcon(Rename24Filled, Rename24Regular);
 const DeleteIcon = bundleIcon(Delete24Filled, Delete24Regular);
 
 export default function GameElement(props: IGameElementProps) {
-  const soureBase = 'background';
+  const sourceBase = 'background';
 
   let className = styles.gameElement_main;
   if (props.checked) {
@@ -111,7 +111,7 @@ export default function GameElement(props: IGameElementProps) {
     <>
       <div onClick={props.onClick} className={className} id={props.gameInfo.dir}>
         <img
-          src={`/games/${props.gameInfo.dir}/game/${soureBase}/${props.gameInfo.cover}`}
+          src={`/games/${props.gameInfo.dir}/game/${sourceBase}/${props.gameInfo.cover.trim()}`}
           alt={props.gameInfo.name}
           className={styles.gameElement_cover}
         />

--- a/packages/origine2/src/pages/dashboard/GameElement.tsx
+++ b/packages/origine2/src/pages/dashboard/GameElement.tsx
@@ -111,7 +111,7 @@ export default function GameElement(props: IGameElementProps) {
     <>
       <div onClick={props.onClick} className={className} id={props.gameInfo.dir}>
         <img
-          src={`/games/${props.gameInfo.dir}/game/${sourceBase}/${props.gameInfo.cover.trim()}`}
+          src={`/games/${props.gameInfo.dir}/game/${sourceBase}/${props.gameInfo.cover}`}
           alt={props.gameInfo.name}
           className={styles.gameElement_cover}
         />

--- a/packages/terre2/src/Modules/manage-game/manage-game.service.ts
+++ b/packages/terre2/src/Modules/manage-game/manage-game.service.ts
@@ -194,7 +194,10 @@ export class ManageGameService {
         .filter((commandText) => commandText !== '')
         .map((commandText) => {
           const i = commandText.indexOf(':');
-          const arr = [commandText.slice(0, i), commandText.slice(i + 1)];
+          const arr = [
+            commandText.slice(0, i).trim(),
+            commandText.slice(i + 1).trim(),
+          ];
           config[arr[0]] = arr[1];
         });
     }
@@ -623,13 +626,19 @@ export class ManageGameService {
         );
         await this.webgalFs.mkdir(
           // eslint-disable-next-line prettier/prettier
-          `${androidExportDir}/app/src/main/java/${gameConfig.Package_name.replace(/\./g, '/')}`,
+          `${androidExportDir}/app/src/main/java/${gameConfig.Package_name.replace(
+            /\./g,
+            '/',
+          )}`,
           '',
         );
         await this.webgalFs.copy(
           `${androidExportDir}/app/src/main/java/MainActivity.kt`,
           // eslint-disable-next-line prettier/prettier
-          `${androidExportDir}/app/src/main/java/${gameConfig.Package_name.replace(/\./g, '/')}/MainActivity.kt`
+          `${androidExportDir}/app/src/main/java/${gameConfig.Package_name.replace(
+            /\./g,
+            '/',
+          )}/MainActivity.kt`,
         );
         await this.webgalFs.deleteFileOrDirectory(
           `${androidExportDir}/app/src/main/java/MainActivity.kt`,


### PR DESCRIPTION
### 问题

Dashboard 中游戏封面图有时无法显示。

**根因**：后端 `getGameConfig` 解析 config.txt 时未对键和值做 trim。当配置项存在首尾空格（如 `Title_img: bg.png`）时，解析出的 key 带前导空格，无法匹配 `Title_img` 字段，导致封面图路径落空、请求 404。

### 改动

- `packages/terre2/src/Modules/manage-game/manage-game.service.ts`
  - getGameConfig 解析 config.txt 时对 key 和 value 均调用 trim()，修复根因
- 顺带修正`packages/origine2/src/pages/dashboard/GameElement.tsx`变量名拼写 soureBase → sourceBase

### 测试方法

1. 在游戏配置 `Title_img:` 后加一个空格（如 `Title_img: bg.png`）
2. 启动项目（yarn + yarn dev）
3. 进入 Dashboard，确认该游戏封面图正常显示

Fixes #643
