### PR TITLE
chore: name concurrently processes for clearer dev logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "4.6.4",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"yarn dev:terre\" \"yarn dev:origine\" \"yarn dev:start-dev-server\"",
-    "lint": "concurrently \"yarn lint:terre\" \"yarn lint:origine\"",
+    "dev": "concurrently -n terre,origine,dev-server -c cyan,green,magenta \"yarn dev:terre\" \"yarn dev:origine\" \"yarn dev:start-dev-server\"",
+    "lint": "concurrently -n terre,origine -c cyan,green \"yarn lint:terre\" \"yarn lint:origine\"",
     "nsis-bundle": "makensis ./installer.nsi",
     "dev:terre": "cd packages/terre2 && yarn start:debug",
     "dev:origine": "cd packages/origine2 && yarn dev",


### PR DESCRIPTION
## 概述

`concurrently` 同时启动的开发进程此前输出前缀是 `数字`，难以区分日志来源。
本次为各进程加上名称与颜色前缀，提升 `yarn dev` / `yarn lint` 时的可读性。

## 改动

根 `package.json` 两个脚本：

- `dev`：`-n terre,origine,dev-server -c cyan,green,magenta`
- `lint`：`-n terre,origine -c cyan,green`

## 验证

- `yarn dev`：输出分别显示 `[terre]` / `[origine]` / `[dev-server]` 彩色前缀
- `yarn lint`：输出分别显示 `[terre]` / `[origine]` 彩色前缀
